### PR TITLE
ignore projects without an underlying kubernetes namespace

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -55,6 +55,7 @@ module ManageIQ::Providers
 
       def parse_project(project_item)
         project = @data_index.fetch_path(:container_projects, :by_name, project_item.metadata.name)
+        return if project.nil? # ignore openshift projects without an underlying kubernetes namespace
         project[:display_name] = project_item.metadata.annotations['openshift.io/display-name'] unless
             project_item.metadata.annotations.nil?
       end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -356,4 +356,17 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                                   )
     end
   end
+
+  describe "parse_project" do
+    it "handles no underlying namespace" do
+      expect(parser.send(:parse_project,
+                         RecursiveOpenStruct.new(
+                           :metadata   => {
+                             :annotations => {
+                               'openshift.io/display-name' => 'example'
+                             },
+                           },
+                         ))).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1441709
I dont know if this will solve the BZ completely since I cant really recreate the conditions in which this error was met.
for future reference the error logged was:
 ```
[----] E, [2017-04-11T15:35:03.125167 #12512:819138] ERROR -- : [NoMethodError]: undefined method `merge!' for nil:NilClass  Method:[rescue in block in refresh]
[----] E, [2017-04-11T15:35:03.125401 #12512:819138] ERROR -- : /var/www/miq/vmdb/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb:64:in `parse_project'
``` 
@moolitayer @cben Please review
cc @simon3z 