### PR TITLE
openshift_connect reuse kubernetes_connect

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -32,15 +32,8 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
     end
 
     def openshift_connect(hostname, port, options)
-      require 'kubeclient'
-
-      Kubeclient::Client.new(
-        raw_api_endpoint(hostname, port, '/oapi'),
-        options[:version] || api_version,
-        :ssl_options    => Kubeclient::Client::DEFAULT_SSL_OPTIONS.merge(options[:ssl_options] || {}),
-        :auth_options   => kubernetes_auth_options(options),
-        :http_proxy_uri => VMDB::Util.http_proxy_uri
-      )
+      options = {:path => '/oapi', :version => api_version}.merge(options)
+      kubernetes_connect(hostname, port, options)
     end
   end
 


### PR DESCRIPTION
#We've been keeping 2 nearly-same functions in sync, especially painful after repo split:
- https://github.com/ManageIQ/manageiq-providers-kubernetes/blob/294010317/app/models/manageiq/providers/kubernetes/container_manager_mixin.rb#L22-L32
- https://github.com/ManageIQ/manageiq-providers-openshift/blob/1a25fff41f3/app/models/manageiq/providers/openshift/container_manager_mixin.rb#L34-L44

@zakiva @moolitayer Please review carefully.

- Minor change: now respects `options[:path]`, previously was forcing `/oapi`.
- Does `connect_client` still work right?  It sets `:service` which chooses `kubernetes_connect`/`openshift_connect`, but it also provides `:path`, `:version` which AFAICT covers both distinctions between them.  I suspect you previously passed `:service` here to work around forced `/oapi`...
- Do we need openshift's `api_version` method distinction from parent's `kubernetes_version` (which `kubernetes/container_manager.rb` also aliases as `api_version`)?  Both are de-facto `v1` so this is effectively dead code.  Anyway that's for another PR.

I'd like to see this backported, so that later changes touching only `kubernetes_connect` will be backportable without remembering to also change `openshift_connect`...
But my hunch is we don't want to backport right now (not a blocker).