### PR TITLE
[WIP] openshift_connect: use kubernetes timeout settings

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -39,7 +39,11 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
         options[:version] || api_version,
         :ssl_options    => Kubeclient::Client::DEFAULT_SSL_OPTIONS.merge(options[:ssl_options] || {}),
         :auth_options   => kubernetes_auth_options(options),
-        :http_proxy_uri => VMDB::Util.http_proxy_uri
+        :http_proxy_uri => VMDB::Util.http_proxy_uri,
+        :timeouts       => {
+          :open => Settings.ems.ems_kubernetes.open_timeout.to_f_with_method,
+          :read => Settings.ems.ems_kubernetes.read_timeout.to_f_with_method
+        }
       )
     end
   end


### PR DESCRIPTION
WIP only because waiting for gem release.  @moolitayer @agrare Please review.

Openshift half of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/10.
**This PR is unnecessary if we merge #7, but is that safe to backport?**

Depends on kubeclient additions https://github.com/abonas/kubeclient/pull/244 or backported https://github.com/abonas/kubeclient/pull/246

Tested:
- [x] [Exercised](https://github.com/abonas/kubeclient/pull/246#issuecomment-298221765) in rails console and refresh, events, SSA in manageiq, confirmed low enough values cause timeouts.
- [x] [Green against kubeclient from git](https://travis-ci.org/cben/manageiq-providers-openshift/builds/227560531)
- [x] core manageiq tests passed locally with this, but I don't think they cover anything relevant.

https://bugzilla.redhat.com/show_bug.cgi?id=1440950
@miq-bot add-label euwe/yes, fine/yes (actually we plan a 5.7.1 hotfix but I suppose we also want normal backports, so customer uprading will not lose hotfix functionality?)