### PR TITLE
move kubernetes related events

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,39 +3,6 @@
   :ems_openshift:
     :event_handling:
       :event_groups:
-        :addition:
-          :critical:
-            - CONTAINER_CREATED
-            - REPLICATOR_SUCCESSFULCREATE
-            - REPLICATOR_FAILEDCREATE
-        :status:
-          :critical:
-            - NODE_NODEREADY
-            - NODE_NODENOTREADY
-            - POD_FAILEDVALIDATION
-            - POD_DEADLINEEXCEEDED
-            - POD_INSUFFICIENTFREECPU
-            - POD_NODESELECTORMISMATCHING
-            - POD_SCHEDULED
-            - POD_FAILEDSCHEDULING
-            - CONTAINER_UNHEALTHY
-            - CONTAINER_KILLING
-            - CONTAINER_STARTED
-            - CONTAINER_STOPPED
-        :power:
-          :critical:
-            - NODE_REBOOTED
-            - NODE_NODESCHEDULABLE
-            - NODE_NODENOTSCHEDULABLE
-        :storage:
-          :critical:
-            - NODE_FAILEDMOUNT
-            - NODE_INVALIDDISKCAPACITY
-            - POD_OUTOFDISK
-            - POD_INSUFFICIENTFREEMEMORY
-        :network:
-          :critical:
-            - POD_HOSTPORTCONFLICT
 :http_proxy:
   :openshift:
     :host:


### PR DESCRIPTION
Moving irrelevant events to from openshift-provider to the correct place - kubernetes-provider.
cc: @cben @simon3z 