### PR TITLE
Make recursive openstruct an explicit dependency

### DIFF
--- a/manageiq-providers-openshift.gemspec
+++ b/manageiq-providers-openshift.gemspec
@@ -14,5 +14,6 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,lib}/**/*"]
 
   s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
+  s.add_development_dependency "recursive-open-struct",     "~> 1.0.0"
   s.add_development_dependency "simplecov"
 end


### PR DESCRIPTION
Previously, we got this dependency implicitly through manageiq,
kubeclient, etc.  Since we use this heavily in tests here, we should
state our reliance on this gem.

Needed for: ManageIQ/manageiq#15096

@simon3z please review