### PR TITLE
Move image registered_on field to openshift provider

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -205,6 +205,12 @@ module ManageIQ::Providers
             )
           end
         end
+
+        openshift_metadata = openshift_image[:metadata]
+        new_result[:registered_on] = if openshift_metadata && openshift_metadata[:creationTimestamp]
+                                       Time.parse(openshift_metadata[:creationTimestamp]).utc
+                                     end
+
         new_result
       end
     end


### PR DESCRIPTION
**Deiscription**

We currently insert a wrong place-holder value to the `ContainerImage#registered_on` field `:registered_on => Time.now.utc`

This PR remove this place-holder value from the Kubernetes provider, and insert the currect value in a new PR in the OpenShift provider.

Issue: https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/17
Kubernetes PR: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/23
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1454329