### PR TITLE
Add some missing refresher specs

### DIFF
--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -304,9 +304,15 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(@container_template.ext_management_system).to eq(@ems)
     expect(@container_template.container_project).to eq(ContainerProject.find_by(:name => "openshift-infra"))
     expect(@container_template.container_template_parameters.count).to eq(4)
-    expect(@container_template.container_template_parameters.last).to have_attributes(
-      :name => "NODE"
-    )
+    expect(@container_template.container_template_parameters.find_by(:name => "NODE")).to have_attributes(
+      :description  => "The node number for the Cassandra cluster.",
+      :display_name => nil,
+      :ems_created_on => nil,
+      :value        => nil,
+      :generate     => nil,
+      :from         => nil,
+      :required     => true,
+     )
   end
 
   def assert_specific_unused_container_image(metadata:, connected:)

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -320,14 +320,14 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(@container_template.container_project).to eq(ContainerProject.find_by(:name => "openshift-infra"))
     expect(@container_template.container_template_parameters.count).to eq(4)
     expect(@container_template.container_template_parameters.find_by(:name => "NODE")).to have_attributes(
-      :description  => "The node number for the Cassandra cluster.",
-      :display_name => nil,
+      :description    => "The node number for the Cassandra cluster.",
+      :display_name   => nil,
       :ems_created_on => nil,
-      :value        => nil,
-      :generate     => nil,
-      :from         => nil,
-      :required     => true,
-     )
+      :value          => nil,
+      :generate       => nil,
+      :from           => nil,
+      :required       => true,
+    )
   end
 
   def assert_specific_unused_container_image(metadata:, connected:)

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -162,6 +162,14 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(@container.container_group).to have_attributes(
       :name => "metrics-deployer-frcf1"
     )
+
+    # TODO: move to kubernetes refresher test (needs cassette containing seLinuxOptions)
+    expect(@container.container_definition.security_context).to have_attributes(
+      :se_linux_user  => nil,
+      :se_linux_role  => nil,
+      :se_linux_type  => nil,
+      :se_linux_level => "s0:c6,c0"
+    )
   end
 
   def assert_specific_container_group

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -281,8 +281,10 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   end
 
   def assert_specific_container_build_pod
+    # TODO: record 2 builds of same name in different projects
     @container_build_pod = ContainerBuildPod.find_by(:name => "python-project-1")
     expect(@container_build_pod).to have_attributes(
+      :namespace                     => "python-project",
       :name                          => "python-project-1",
       :phase                         => "Complete",
       :reason                        => nil,
@@ -292,6 +294,11 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(@container_build_pod.container_build).to eq(
       ContainerBuild.find_by(:name => "python-project")
     )
+
+    expect(@container_build_pod.container_group).to eq(
+      ContainerGroup.find_by(:name => "python-project-1-build")
+    )
+    expect(@container_build_pod.container_group.container_build_pod).to eq(@container_build_pod)
   end
 
   def assert_specific_container_template


### PR DESCRIPTION
Extracted from https://github.com/ManageIQ/manageiq/issues/14337.
Addresses the test points from ManageIQ/manageiq-providers-kubernetes#27 that I could cover
without rerecording the main casette.
(I'll want to rerecord at some point but don't want to block on it now...)

- SecurityContext is a Kubernetes concept, but we only have it in openshift casette, so tested here.

@zakiva @moolitayer Please review.
@miq-bot add-label test