### PR TITLE
Add openshift monitoring manager

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -9,6 +9,13 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   require_nested :Refresher
   require_nested :OrchestrationStack
 
+  # Override HasMonitoringManagerMixin
+  has_one :monitoring_manager,
+          :foreign_key => :parent_ems_id,
+          :class_name  => "ManageIQ::Providers::Openshift::MonitoringManager",
+          :autosave    => true,
+          :dependent   => :destroy
+
   def self.ems_type
     @ems_type ||= "openshift".freeze
   end

--- a/app/models/manageiq/providers/openshift/monitoring_manager.rb
+++ b/app/models/manageiq/providers/openshift/monitoring_manager.rb
@@ -1,0 +1,18 @@
+module ManageIQ::Providers
+  class Openshift::MonitoringManager < ManageIQ::Providers::MonitoringManager
+    include ManageIQ::Providers::Kubernetes::MonitoringManagerMixin
+
+    belongs_to :parent_manager,
+               :foreign_key => :parent_ems_id,
+               :class_name  => "ManageIQ::Providers::Openshift::ContainerManager",
+               :inverse_of  => :monitoring_manager
+
+    def self.ems_type
+      @ems_type ||= "openshift_monitor".freeze
+    end
+
+    def self.description
+      @description ||= "Openshift Monitor".freeze
+    end
+  end
+end


### PR DESCRIPTION
This is the third item of ManageIQ/manageiq-providers-kubernetes#39

Depends on: ManageIQ/manageiq#15354