### PR TITLE
Adding openshift_container_images

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/container_image.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_image.rb
@@ -1,0 +1,10 @@
+class ManageIQ::Providers::Openshift::ContainerManager::ContainerImage < ContainerImage
+  def annotate_deny_execution(causing_policy)
+    ext_management_system.annotate(
+      "image",
+      digest,
+      "security.manageiq.org/failed-policy" => causing_policy,
+      "images.openshift.io/deny-execution"  => "true"
+    )
+  end
+end

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -175,6 +175,8 @@ module ManageIQ::Providers
         ref = "#{ContainerImage::DOCKER_PULLABLE_PREFIX}#{id}"
         new_result = parse_container_image(id, ref)
 
+        new_result[:type] = 'ManageIQ::Providers::Openshift::ContainerManager::ContainerImage'
+
         if openshift_image[:dockerImageManifest].present?
           begin
             json = JSON.parse(openshift_image[:dockerImageManifest])

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -17,7 +17,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
       RecursiveOpenStruct.new(
         :metadata             => {
           :name              => image_digest,
-          :creationTimestamp => '2015-08-17T09:16:46Z'
+          :creationTimestamp => '2015-08-17T09:16:46Z',
+          :uid               => '123'
         },
         :dockerImageReference => "#{image_registry}:#{image_registry_port}/#{image_name}@#{image_digest}",
         :dockerImageManifest  => '{"name": "%s", "tag": "%s"}' % [image_name, image_tag],
@@ -72,6 +73,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                          image_from_openshift)).to eq(
                            :name                     => image_name,
                            :registered_on            => Time.parse('2015-08-17T09:16:46Z').utc,
+                           :type                     => 'ManageIQ::Providers::Openshift::ContainerManager::ContainerImage',
                            :digest                   => image_digest,
                            :image_ref                => image_ref,
                            :tag                      => image_tag,
@@ -105,7 +107,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                            :digest                   => nil,
                            :image_ref                => "docker-pullable://sha256:abcdefg",
                            :name                     => "sha256",
-                           :tag                      => "abcdefg"
+                           :tag                      => "abcdefg",
+                           :type                     => "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage",
                          )
     end
 
@@ -123,6 +126,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                            :docker_version           => nil,
                            :size                     => nil,
                            :labels                   => [],
+                           :type                     => "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage",
                          )
     end
 
@@ -145,7 +149,8 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                            :environment_variables    => {},
                            :size                     => nil,
                            :labels                   => [],
-                           :docker_labels            => []
+                           :docker_labels            => [],
+                           :type                     => "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage",
                          )
     end
 

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -1,6 +1,7 @@
 describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   let(:all_images_count) { 40 } # including /oapi/v1/images data
   let(:pod_images_count) { 12 } # only images mentioned by pods
+  let(:images_managed_by_openshift_count) { 32 } # only images from /oapi/v1/images
 
   before(:each) do
     allow(MiqServer).to receive(:my_zone).and_return("default")
@@ -141,6 +142,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     expect(ContainerTemplate.count).to eq(26)
     expect(ContainerImage.count).to eq(all_images_count)
     expect(ContainerImage.joins(:containers).distinct.count).to eq(pod_images_count)
+    expect(ManageIQ::Providers::Openshift::ContainerManager::ContainerImage.count).to eq(images_managed_by_openshift_count)
   end
 
   def assert_ems


### PR DESCRIPTION
Addes openshift_container_images to the openshift provider.
Adding parsing for `ems_ref` for images originating from Openshift.

based on: https://github.com/ManageIQ/manageiq/pull/15386