### PR TITLE
Get rid of magic and soon buggy ["table"] RecursiveOpenStruct access

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -81,7 +81,7 @@ module ManageIQ::Providers
         )
 
         new_result[:project] = @data_index.fetch_path(path_for_entity("project"), :by_name,
-                                                      route.metadata["table"][:namespace])
+                                                      route.metadata.namespace)
         new_result[:container_service] = @data_index.fetch_path(path_for_entity("service"), :by_namespace_and_name,
                                                                 new_result[:namespace], get_service_name(route))
         new_result
@@ -111,7 +111,7 @@ module ManageIQ::Providers
         )
 
         new_result[:project] = @data_index.fetch_path(path_for_entity("project"), :by_name,
-                                                      build.metadata["table"][:namespace])
+                                                      build.metadata.namespace)
         new_result
       end
 


### PR DESCRIPTION
See https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/48.

The `obj["table"][:namespace]` workaround is not needed since 2015,
and relies on a bug that is fixed in recursive-open-struct 1.0.3.
We happen to be pegged to =1.0.0 by kubeclient & image-inspector-client
(since at least capablanca) but would break soon.

Tested against both r-o-s 1.0.0 and 1.0.4.

@miq-bot add-label bug, technical debt