### PR TITLE
Add OrchestrationStack for container template provisioning.

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -7,6 +7,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
+  require_nested :OrchestrationStack
 
   def self.ems_type
     @ems_type ||= "openshift".freeze

--- a/app/models/manageiq/providers/openshift/container_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/orchestration_stack.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Openshift::ContainerManager::OrchestrationStack < ManageIQ::Providers::ContainerManager::OrchestrationStack
+  require_nested :Status
+end

--- a/app/models/manageiq/providers/openshift/container_manager/orchestration_stack/status.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/orchestration_stack/status.rb
@@ -1,0 +1,9 @@
+class ManageIQ::Providers::Openshift::ContainerManager::OrchestrationStack::Status < ::OrchestrationStack::Status
+  def succeeded?
+    status.downcase == "completed"
+  end
+
+  def failed?
+    status.downcase =~ /failed$/
+  end
+end

--- a/spec/models/manageiq/providers/openshift/container_manager/orchestration_stack_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/orchestration_stack_spec.rb
@@ -1,0 +1,31 @@
+describe ManageIQ::Providers::Openshift::ContainerManager::OrchestrationStack do
+  let(:ems) { FactoryGirl.create(:ems_openshift) }
+  let(:ctp) { FactoryGirl.create(:container_template_parameter, :name => 'var1', :value => 'p1', :required => true) }
+  let(:container_template) do
+    FactoryGirl.create(:container_template, :ems_id => ems.id).tap do |ct|
+      ct.container_template_parameters = [ctp]
+    end
+  end
+  let(:container_route) do
+    {
+      :kind       => "Route",
+      :apiVersion => "v1",
+      :miq_class  => ContainerRoute,
+      :metadata   => {:name => "dotnet-example", :namespace => "provision-test", :uid => "135f11fa-55e5-11e7-8449-fa163e02640a", :creationTimestamp => "2017-06-20T18:20:01Z"}
+    }
+  end
+
+  before { allow(described_class).to receive(:raw_create_stack).and_return([container_route]) }
+
+  it '.create_stack' do
+    stack    = described_class.create_stack(container_template, container_template.container_template_parameters.to_a, 'my-project')
+    resource = stack.resources.first
+    expect(resource.name).to              eq(container_route[:metadata][:name])
+    expect(resource.ems_ref).to           eq(container_route[:metadata][:uid])
+    expect(resource.start_time).to        eq(container_route[:metadata][:creationTimestamp])
+    expect(resource.physical_resource).to eq(container_route[:metadata][:namespace])
+    expect(resource.logical_resource).to  eq(container_route[:kind])
+    expect(resource.resource_category).to eq(container_route[:miq_class].name)
+    expect(resource.description).to       eq(container_route[:apiVersion])
+  end
+end


### PR DESCRIPTION
Add OrchestrationStack to track the provider created objects during provisioning.

Depends on https://github.com/ManageIQ/manageiq/pull/15429.
Depends on https://github.com/ManageIQ/manageiq/pull/15475.

https://www.pivotaltracker.com/story/show/134027413