### PR TITLE
Add ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate.

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -1,13 +1,15 @@
 class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::ContainerManager
   include ManageIQ::Providers::Openshift::ContainerManagerMixin
 
+  require_nested :ContainerImage
+  require_nested :ContainerTemplate
   require_nested :EventCatcher
   require_nested :EventParser
   require_nested :MetricsCollectorWorker
+  require_nested :OrchestrationStack
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
-  require_nested :OrchestrationStack
 
   # Override HasMonitoringManagerMixin
   has_one :monitoring_manager,

--- a/app/models/manageiq/providers/openshift/container_manager/container_template.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_template.rb
@@ -1,0 +1,3 @@
+class ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate < ManageIQ::Providers::ContainerManager::ContainerTemplate
+  include ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplateMixin
+end

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -291,6 +291,7 @@ module ManageIQ::Providers
         new_result[:container_template_parameters] = parse_template_parameters(template.parameters)
         new_result[:labels] = parse_labels(template)
         new_result[:objects] = template.objects.to_a.collect(&:to_h)
+        new_result[:type] = "ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate"
         new_result
       end
 

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -428,6 +428,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                                    :resource_version              => '172339',
                                    :labels                        => [],
                                    :objects                       => [],
+                                   :type                          => "ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate",
                                    :container_template_parameters => [
                                      {:name         => 'IMAGE_VERSION',
                                       :display_name => 'Image Version',
@@ -459,6 +460,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                                    :resource_version              => '242359',
                                    :labels                        => [],
                                    :objects                       => [],
+                                   :type                          => "ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate",
                                    :container_template_parameters => [])
     end
   end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -435,6 +435,7 @@ shared_examples "openshift refresher VCR tests" do
     @container_template = ContainerTemplate.find_by(:name => "hawkular-cassandra-node-emptydir")
     expect(@container_template).to have_attributes(
       :name             => "hawkular-cassandra-node-emptydir",
+      :type             => "ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate",
       :resource_version => "871"
     )
 


### PR DESCRIPTION
Part of https://github.com/ManageIQ/manageiq/pull/15523.
Depends on https://github.com/ManageIQ/manageiq-schema/pull/35.
Depends on https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/79.

@miq-bot add_label refactoring