### PR TITLE
Separate data_index lookups from parsing

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -8,16 +8,16 @@ module ManageIQ::Providers
         get_builds(inventory)
         get_build_pods(inventory)
         get_templates(inventory)
-        get_openshift_images(inventory) if options.get_container_images
+        get_or_merge_openshift_images(inventory) if options.get_container_images
         EmsRefresh.log_inv_debug_trace(@data, "data:")
         @data
       end
 
-      def get_openshift_images(inventory)
-        inventory["image"].each { |img| get_openshift_image(img) }
+      def get_or_merge_openshift_images(inventory)
+        inventory["image"].each { |img| get_or_merge_openshift_image(img) }
       end
 
-      def get_openshift_image(openshift_image)
+      def get_or_merge_openshift_image(openshift_image)
         openshift_result = parse_openshift_image(openshift_image)
         # This hides @data_index reading and writing.
         container_result = parse_container_image(openshift_result.delete(:id),

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -3,7 +3,7 @@ module ManageIQ::Providers
     class ContainerManager::RefreshParser < ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser
       def ems_inv_to_hashes(inventory, options = Config::Options.new)
         super(inventory, options)
-        get_projects(inventory)
+        merge_projects_into_namespaces(inventory)
         get_routes(inventory)
         get_builds(inventory)
         get_build_pods(inventory)
@@ -65,7 +65,7 @@ module ManageIQ::Providers
       end
 
       # Merge into results of parse_namespace
-      def get_projects(inventory)
+      def merge_projects_into_namespaces(inventory)
         key = path_for_entity("namespace")
         inventory["project"].each do |item|
           project = parse_project(item)

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -73,6 +73,7 @@ module ManageIQ::Providers
         process_collection(inventory["template"], key) { |n| parse_template(n) }
 
         @data[key].each do |ct|
+          ct[:container_project] = @data_index.fetch_path(path_for_entity("project"), :by_name, ct[:namespace])
           @data_index.store_path(key, :by_namespace_and_name, ct[:namespace], ct[:name], ct)
         end
       end
@@ -170,7 +171,6 @@ module ManageIQ::Providers
         new_result[:container_template_parameters] = parse_template_parameters(template.parameters)
         new_result[:labels] = parse_labels(template)
         new_result[:objects] = template.objects.to_a.collect(&:to_h)
-        new_result[:container_project] = @data_index.fetch_path(path_for_entity("project"), :by_name, new_result[:namespace])
         new_result
       end
 

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -458,7 +458,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     end
   end
 
-  describe "get_projects" do
+  describe "merge_projects_into_namespaces" do
     let(:inventory) do
       {
         'project' => [
@@ -475,7 +475,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     end
 
     it "handles no underlying namespace" do
-      parser.send(:get_projects, inventory)
+      parser.send(:merge_projects_into_namespaces, inventory)
       expect(parser.instance_variable_get(:@data)[:container_projects]).to be_blank
       expect(parser.instance_variable_get(:@data_index).fetch_path(:container_projects, :by_name)).to be_blank
     end
@@ -484,7 +484,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
       data_index = parser.instance_variable_get(:@data_index)
       data_index.store_path(:container_projects, :by_name, 'myproj', {:ems_ref => 'some-uuid'})
 
-      parser.send(:get_projects, inventory)
+      parser.send(:merge_projects_into_namespaces, inventory)
       expect(data_index.fetch_path(:container_projects, :by_name, 'myproj')).to eq(
         :ems_ref      => 'some-uuid',
         :display_name => 'example',

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -423,7 +423,6 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                                    :resource_version              => '172339',
                                    :labels                        => [],
                                    :objects                       => [],
-                                   :container_project             => nil,
                                    :container_template_parameters => [
                                      {:name         => 'IMAGE_VERSION',
                                       :display_name => 'Image Version',
@@ -455,7 +454,6 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                                    :resource_version              => '242359',
                                    :labels                        => [],
                                    :objects                       => [],
-                                   :container_project             => nil,
                                    :container_template_parameters => [])
     end
   end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -68,7 +68,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     end
 
     it "collects data from openshift images correctly" do
-      expect(parser.send(:parse_openshift_image,
+      expect(parser.send(:get_openshift_image,
                          image_from_openshift)).to eq(
                            :name                     => image_name,
                            :registered_on            => Time.parse('2015-08-17T09:16:46Z').utc,
@@ -99,7 +99,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     end
 
     it "handles openshift images without dockerImageManifest and dockerImageMetadata" do
-      expect(parser.send(:parse_openshift_image,
+      expect(parser.send(:get_openshift_image,
                          image_without_dockerImage_fields).except(:registered_on)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,
@@ -110,7 +110,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     end
 
     it "handles openshift image without dockerConfig" do
-      expect(parser.send(:parse_openshift_image,
+      expect(parser.send(:get_openshift_image,
                          image_without_dockerConfig)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,
@@ -128,7 +128,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
     # check https://bugzilla.redhat.com/show_bug.cgi?id=1414508
     it "handles openshift image without environment variables" do
-      expect(parser.send(:parse_openshift_image,
+      expect(parser.send(:get_openshift_image,
                          image_without_environment_variables)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -3,7 +3,7 @@ require 'recursive-open-struct'
 describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
   let(:parser) { described_class.new }
 
-  describe "get_openshift_images" do
+  describe "get_or_merge_openshift_images" do
     let(:image_name) { "image_name" }
     let(:image_tag) { "my_tag" }
     let(:image_digest) { "sha256:abcdefg" }
@@ -68,7 +68,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     end
 
     it "collects data from openshift images correctly" do
-      expect(parser.send(:get_openshift_image,
+      expect(parser.send(:get_or_merge_openshift_image,
                          image_from_openshift)).to eq(
                            :name                     => image_name,
                            :registered_on            => Time.parse('2015-08-17T09:16:46Z').utc,
@@ -99,7 +99,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     end
 
     it "handles openshift images without dockerImageManifest and dockerImageMetadata" do
-      expect(parser.send(:get_openshift_image,
+      expect(parser.send(:get_or_merge_openshift_image,
                          image_without_dockerImage_fields).except(:registered_on)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,
@@ -110,7 +110,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
     end
 
     it "handles openshift image without dockerConfig" do
-      expect(parser.send(:get_openshift_image,
+      expect(parser.send(:get_or_merge_openshift_image,
                          image_without_dockerConfig)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,
@@ -128,7 +128,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
     # check https://bugzilla.redhat.com/show_bug.cgi?id=1414508
     it "handles openshift image without environment variables" do
-      expect(parser.send(:get_openshift_image,
+      expect(parser.send(:get_or_merge_openshift_image,
                          image_without_environment_variables)).to eq(
                            :container_image_registry => nil,
                            :digest                   => nil,
@@ -164,7 +164,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
       inventory = {"image" => [image_from_openshift,]}
 
-      parser.get_openshift_images(inventory)
+      parser.get_or_merge_openshift_images(inventory)
       expect(parser.instance_variable_get('@data')[:container_images].size).to eq(1)
       expect(parser.instance_variable_get('@data')[:container_images][0]).to eq(
         parser.instance_variable_get('@data_index')[:container_image][:by_digest].values[0])
@@ -190,7 +190,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
 
       inventory = {"image" => [image_from_openshift,]}
 
-      parser.get_openshift_images(inventory)
+      parser.get_or_merge_openshift_images(inventory)
       expect(parser.instance_variable_get('@data')[:container_images].size).to eq(1)
       expect(parser.instance_variable_get('@data')[:container_images][0]).to eq(
         parser.instance_variable_get('@data_index')[:container_image][:by_digest].values[0]
@@ -203,7 +203,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
       def parse_single_openshift_image_with_registry
         inventory = {"image" => [image_from_openshift]}
 
-        parser.get_openshift_images(inventory)
+        parser.get_or_merge_openshift_images(inventory)
         expect(parser.instance_variable_get('@data_index')[:container_image_registry][:by_host_and_port].size).to eq(1)
         expect(parser.instance_variable_get('@data')[:container_image_registries].size).to eq(1)
       end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresh_parser_spec.rb
@@ -262,8 +262,6 @@ describe ManageIQ::Providers::Openshift::ContainerManager::RefreshParser do
                                  :ems_created_on              => '2015-08-17T09:16:46Z',
                                  :resource_version            => '165339',
                                  :service_account             => 'service_account_name',
-                                 :project                     => nil,
-
                                  :build_source_type           => 'Git',
                                  :source_binary               => nil,
                                  :source_dockerfile           => nil,

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -353,16 +353,19 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
   end
 
   def assert_specific_container_project
-    @container_pr = ContainerProject.find_by(:name => "default")
+    @container_pr = ContainerProject.find_by(:name => "python-project")
     expect(@container_pr).to have_attributes(
-      :name         => "default",
-      :display_name => nil
+      :name         => "python-project",
+      :display_name => "Python project",
     )
 
-    expect(@container_pr.container_groups.count).to eq(3)
-    expect(@container_pr.container_routes.count).to eq(2)
-    expect(@container_pr.container_replicators.count).to eq(4)
-    expect(@container_pr.container_services.count).to eq(4)
+    expect(@container_pr.container_groups.count).to eq(5)
+    expect(@container_pr.containers.count).to eq(5)
+    expect(@container_pr.container_replicators.count).to eq(1)
+    expect(@container_pr.container_routes.count).to eq(1)
+    expect(@container_pr.container_services.count).to eq(1)
+    expect(@container_pr.container_builds.count).to eq(1)
+    expect(ContainerBuildPod.where(:namespace => @container_pr.name).count).to eq(1)
     expect(@container_pr.ext_management_system).to eq(@ems)
   end
 


### PR DESCRIPTION
Openshift half of https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/46, same motivation & approach.

- Images only partially untangled — the real complication stayed in kubernetes `parse_container_image` reading and writing `data_index` for both images & registries :-(
  I probably can live with that for initial graph refresh.

@miq-bot add-label refactoring
@enoodle @zeari @moolitayer @zakiva @yaacov Please review.

- [x] also tested locally against deletion tests #18.

towards RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1470021
