### PR TITLE
Use the kubernetes options for Openshift

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -10,6 +10,9 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   require_nested :RefreshParser
   require_nested :RefreshWorker
   require_nested :Refresher
+  require_nested :Options
+
+  include ManageIQ::Providers::Openshift::ContainerManager::Options
 
   # Override HasMonitoringManagerMixin
   has_one :monitoring_manager,

--- a/app/models/manageiq/providers/openshift/container_manager/options.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/options.rb
@@ -1,0 +1,4 @@
+module ManageIQ::Providers::Openshift::ContainerManager::Options
+  extend ActiveSupport::Concern
+  include ManageIQ::Providers::Kubernetes::ContainerManager::Options
+end


### PR DESCRIPTION
Using https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/45 for Openshift provider options.

This is required for using the options field with the Openshift provider as it adds the static description of the options (That is then being served through the API to the UI to present to the user when editing the options)