### PR TITLE
Refresher: Split collection from parsing methods

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresher.rb
@@ -28,17 +28,17 @@ module ManageIQ::Providers
         request_entities = OPENSHIFT_ENTITIES.dup
         request_entities << {:name => 'images'} if refresher_options.get_container_images
 
-        kube_entities = ems.with_provider_connection(:service => KUBERNETES_EMS_TYPE) do |kubeclient|
+        kube_inventory = ems.with_provider_connection(:service => KUBERNETES_EMS_TYPE) do |kubeclient|
           fetch_entities(kubeclient, KUBERNETES_ENTITIES)
         end
-        openshift_entities = ems.with_provider_connection do |openshift_client|
+        openshift_inventory = ems.with_provider_connection do |openshift_client|
           fetch_entities(openshift_client, request_entities)
         end
 
-        entities = openshift_entities.merge(kube_entities)
-        entities["additional_attributes"] = fetch_hawk_inv(ems) || {}
-        EmsRefresh.log_inv_debug_trace(entities, "inv_hash:")
-        [[ems, entities]]
+        inventory = openshift_inventory.merge(kube_inventory)
+        inventory["additional_attributes"] = fetch_hawk_inv(ems) || {}
+        EmsRefresh.log_inv_debug_trace(inventory, "inv_hash:")
+        [[ems, inventory]]
       end
 
       def parse_targeted_inventory(ems, _target_is_ems, inventory)

--- a/app/models/manageiq/providers/openshift/container_manager/refresher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresher.rb
@@ -23,7 +23,8 @@ module ManageIQ::Providers
         return nil
       end
 
-      def parse_legacy_inventory(ems)
+      # Full refresh. Collecting immediately. Don't have separate Collector classes.
+      def collect_inventory_for_targets(ems, _targets)
         request_entities = OPENSHIFT_ENTITIES.dup
         request_entities << {:name => 'images'} if refresher_options.get_container_images
 
@@ -33,14 +34,18 @@ module ManageIQ::Providers
         openshift_entities = ems.with_provider_connection do |openshift_client|
           fetch_entities(openshift_client, request_entities)
         end
+
         entities = openshift_entities.merge(kube_entities)
         entities["additional_attributes"] = fetch_hawk_inv(ems) || {}
         EmsRefresh.log_inv_debug_trace(entities, "inv_hash:")
+        [[ems, entities]]
+      end
 
+      def parse_targeted_inventory(ems, _target_is_ems, inventory)
         if refresher_options.inventory_object_refresh
-          ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_inv_collections(ems, entities, refresher_options)
+          ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_inv_collections(ems, inventory, refresher_options)
         else
-          ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(entities, refresher_options)
+          ManageIQ::Providers::Openshift::ContainerManager::RefreshParser.ems_inv_to_hashes(inventory, refresher_options)
         end
       end
     end


### PR DESCRIPTION
Concrete benefit is separate `realtime_block` timing.

similar to
https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/82
I believe they're independent can be merged in either order.

@miq-bot add-label refactoring