### PR TITLE
Enable check metadata not deleted specs

### DIFF
--- a/app/models/manageiq/providers/openshift/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/inventory/persister/container_manager.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::Openshift::Inventory::Persister::ContainerManager < M
     # Skipping these InventoryCollections (instead of returning empty ones)
     # to at least retain existing metadata if it was true and is now false.
     if options.get_container_images
-      initialize_custom_attributes_collections(manager.container_images, %w(labels docker_labels))
+      initialize_custom_attributes_collections(manager, :container_images, %w(labels docker_labels))
     end
   end
 end

--- a/app/models/manageiq/providers/openshift/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/inventory/persister/container_manager.rb
@@ -7,7 +7,7 @@ class ManageIQ::Providers::Openshift::Inventory::Persister::ContainerManager < M
     # Skipping these InventoryCollections (instead of returning empty ones)
     # to at least retain existing metadata if it was true and is now false.
     if options.get_container_images
-      initialize_custom_attributes_collections(manager, :container_images, %w(labels docker_labels))
+      initialize_custom_attributes_collections(@collections[:container_images], %w(labels docker_labels))
     end
   end
 end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -1,5 +1,5 @@
 # instantiated at the end, for both classical and graph refresh
-shared_examples "openshift refresher VCR tests" do |check_metadata_not_deleted: true|
+shared_examples "openshift refresher VCR tests" do
   let(:all_images_count) { 40 } # including /oapi/v1/images data
   let(:pod_images_count) { 12 } # only images mentioned by pods
   let(:images_managed_by_openshift_count) { 32 } # only images from /oapi/v1/images
@@ -220,8 +220,6 @@ shared_examples "openshift refresher VCR tests" do |check_metadata_not_deleted: 
   end
 
   it 'will not delete previously collected metadata if store_unused_images = false' do
-    # TODO(cben): investigate, weird that it deletes labels but not docker_labels.
-    skip("graph refresh deletes labels on archived image") unless check_metadata_not_deleted
     normal_refresh
     stub_settings_merge(
       :ems_refresh => {:openshift => {:store_unused_images => false}},
@@ -502,7 +500,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
       end
 
       # TODO: pending proper graph store_unused_images implemetation
-      include_examples "openshift refresher VCR tests", :check_metadata_not_deleted => false
+      include_examples "openshift refresher VCR tests"
     end
 
     context "with :batch saver" do
@@ -513,7 +511,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
       end
 
       # TODO: pending proper graph store_unused_images implemetation
-      include_examples "openshift refresher VCR tests", :check_metadata_not_deleted => false
+      include_examples "openshift refresher VCR tests"
     end
   end
 end


### PR DESCRIPTION
Depends on:
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/106
- [x] https://github.com/ManageIQ/manageiq/pull/15903
Enable check metadata not deleted specs.