### PR TITLE
Enable graph refresh (batch strategy) by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,9 @@
 :ems_refresh:
   :openshift:
     :refresh_interval: 15.minutes
-    :inventory_object_refresh: false
+    :inventory_object_refresh: true
+    :inventory_collections:
+      :saver_strategy: :batch
     :get_container_images: true
     :store_unused_images: true
 :workers:


### PR DESCRIPTION
Same as https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/112, can be merged in any order.

There are some loose ends (notably tag mapping missing) but we want to get more testing from developers using it.

https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/27
https://bugzilla.redhat.com/show_bug.cgi?id=1470021
