### PR TITLE
Drop Container Component Statuses

### DIFF
--- a/spec/vcr_cassettes/manageiq/providers/openshift/container_manager/refresher.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openshift/container_manager/refresher.yml
@@ -432,46 +432,6 @@ http_interactions:
   recorded_at: Wed, 21 Dec 2016 13:46:20 GMT
 - request:
     method: get
-    uri: https://host.example.com:8443/api/v1/componentstatuses
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.0 (linux-gnu x86_64) ruby/2.3.1p112
-      Authorization:
-      - Bearer theToken
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-store
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 21 Dec 2016 13:46:20 GMT
-      Content-Length:
-      - '917'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"ComponentStatusList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/componentstatuses"},"items":[{"metadata":{"name":"controller-manager","selfLink":"/api/v1/componentstatuses/controller-manager","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        http://127.0.0.1:10252/healthz: dial tcp 127.0.0.1:10252: getsockopt: connection
-        refused"}]},{"metadata":{"name":"scheduler","selfLink":"/api/v1/componentstatuses/scheduler","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: getsockopt: connection
-        refused"}]},{"metadata":{"name":"etcd-0","selfLink":"/api/v1/componentstatuses/etcd-0","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        https://host.example.com:4001/health: remote error: bad certificate"}]}]}
-
-'
-    http_version: 
-  recorded_at: Wed, 21 Dec 2016 13:46:20 GMT
-- request:
-    method: get
     uri: https://host.example.com:8443/oapi/v1
     body:
       encoding: US-ASCII

--- a/spec/vcr_cassettes/manageiq/providers/openshift/container_manager/refresher_after_openshift_deletions.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openshift/container_manager/refresher_after_openshift_deletions.yml
@@ -412,47 +412,6 @@ http_interactions:
   recorded_at: Mon, 17 Jul 2017 12:32:52 GMT
 - request:
     method: get
-    uri: https://host.example.com:8443/api/v1/componentstatuses
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Authorization:
-      - Bearer theToken
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-store
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 17 Jul 2017 12:33:30 GMT
-      Content-Length:
-      - '912'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"ComponentStatusList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/componentstatuses"},"items":[{"metadata":{"name":"scheduler","selfLink":"/api/v1/componentstatusesscheduler","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: getsockopt: connection
-        refused"}]},{"metadata":{"name":"controller-manager","selfLink":"/api/v1/componentstatusescontroller-manager","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        http://127.0.0.1:10252/healthz: dial tcp 127.0.0.1:10252: getsockopt: connection
-        refused"}]},{"metadata":{"name":"etcd-0","selfLink":"/api/v1/componentstatusesetcd-0","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        https://vm-48-232.eng.lab.tlv.redhat.com:4001/health: remote error: tls: bad
-        certificate"}]}]}
-
-'
-    http_version: 
-  recorded_at: Mon, 17 Jul 2017 12:32:52 GMT
-- request:
-    method: get
     uri: https://host.example.com:8443/oapi/v1
     body:
       encoding: US-ASCII

--- a/spec/vcr_cassettes/manageiq/providers/openshift/container_manager/refresher_before_openshift_deletions.yml
+++ b/spec/vcr_cassettes/manageiq/providers/openshift/container_manager/refresher_before_openshift_deletions.yml
@@ -434,47 +434,6 @@ http_interactions:
   recorded_at: Mon, 17 Jul 2017 12:30:53 GMT
 - request:
     method: get
-    uri: https://host.example.com:8443/api/v1/componentstatuses
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      Accept-Encoding:
-      - gzip, deflate
-      User-Agent:
-      - rest-client/2.0.2 (linux-gnu x86_64) ruby/2.3.3p222
-      Authorization:
-      - Bearer theToken
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Cache-Control:
-      - no-store
-      Content-Type:
-      - application/json
-      Date:
-      - Mon, 17 Jul 2017 12:31:31 GMT
-      Content-Length:
-      - '912'
-    body:
-      encoding: UTF-8
-      string: '{"kind":"ComponentStatusList","apiVersion":"v1","metadata":{"selfLink":"/api/v1/componentstatuses"},"items":[{"metadata":{"name":"controller-manager","selfLink":"/api/v1/componentstatusescontroller-manager","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        http://127.0.0.1:10252/healthz: dial tcp 127.0.0.1:10252: getsockopt: connection
-        refused"}]},{"metadata":{"name":"scheduler","selfLink":"/api/v1/componentstatusesscheduler","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        http://127.0.0.1:10251/healthz: dial tcp 127.0.0.1:10251: getsockopt: connection
-        refused"}]},{"metadata":{"name":"etcd-0","selfLink":"/api/v1/componentstatusesetcd-0","creationTimestamp":null},"conditions":[{"type":"Healthy","status":"False","message":"Get
-        https://vm-48-232.eng.lab.tlv.redhat.com:4001/health: remote error: tls: bad
-        certificate"}]}]}
-
-'
-    http_version: 
-  recorded_at: Mon, 17 Jul 2017 12:30:53 GMT
-- request:
-    method: get
     uri: https://host.example.com:8443/oapi/v1
     body:
       encoding: US-ASCII


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/121

Removed (by manual editing) `https://host.example.com:8443/api/v1/componentstatuses` requests from cassette to avoid "unused interactions" error.

@moolitayer @simon3z this should fix the build https://travis-ci.org/ManageIQ/manageiq-providers-openshift/builds

https://bugzilla.redhat.com/show_bug.cgi?id=1485431