### PR TITLE
Don't start CollectorWorker if Graph Refresh disabled

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/inventory_collector_worker.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/inventory_collector_worker.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::Openshift::ContainerManager::InventoryCollectorWorker < ManageIQ::Providers::BaseManager::InventoryCollectorWorker
   require_nested :Runner
+
+  def self.has_required_role?
+    !worker_settings[:disabled] && Settings.fetch_path(:ems_refresh, ems_class.ems_type.to_sym, :inventory_object_refresh)
+  end
 end


### PR DESCRIPTION
Vintage :TM: refresh for container providers doesn't reconnect container
images so having duplicate targets queued by the
InventoryCollectorWorker can lead to duplicate records.  For this reason
we want to disable the InventoryCollectorWorker if
`:inventory_object_refresh` is disabled.