### PR TITLE
Tag mapping in graph refresh

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -131,9 +131,12 @@ module ManageIQ::Providers
           h[:container_project] = lazy_find_project(:name => h[:namespace])
           h[:container_service] = lazy_find_service(h.delete(:container_service_ref))
           custom_attrs = h.extract!(:labels)
+          tags = h.delete(:tags)
+
           container_route = collection.build(h)
 
           get_custom_attributes_graph(container_route, custom_attrs)
+          get_taggings_graph(container_route, tags)
         end
       end
 
@@ -144,9 +147,12 @@ module ManageIQ::Providers
           h = parse_build(data)
           h[:container_project] = lazy_find_project(:name => h[:namespace])
           custom_attrs = h.extract!(:labels)
+          tags = h.delete(:tags)
+
           container_build = collection.build(h)
 
           get_custom_attributes_graph(container_build, custom_attrs)
+          get_taggings_graph(container_build, tags)
         end
       end
 


### PR DESCRIPTION
Covers routes, builds.

Images & templates tag mapping out of scope, they've never worked in old refresh either, will fix separately.

Depends on:
- [x] https://github.com/ManageIQ/manageiq/pull/16453 for specs
- [x]  ManageIQ/manageiq#16499 for fixing that spec
- [x]  (ManageIQ/manageiq#16501 OR revival of reverted ManageIQ/manageiq#16449)
  to define Tag.controlled_by_mapping scope
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/162

Overview/plan issue: https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/126

@miq-bot add-label enhancement, gaprindashvili/yes
https://bugzilla.redhat.com/show_bug.cgi?id=1470021