### PR TITLE
Modify spec to use new target with payload interface

### DIFF
--- a/spec/models/manageiq/providers/openshift/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -56,10 +56,9 @@ shared_examples "openshift refresher VCR targeted refresh tests" do
       :manager     => @ems,
       :association => :container_groups,
       :manager_ref => ems_ref,
-      :options     => {
-        :payload => notice['object'].to_json,
-      },
     )
+
+    target.payload = notice['object'].to_json
 
     EmsRefresh.queue_refresh(target)
   end


### PR DESCRIPTION
The interface is being changed in:
ManageIQ/manageiq-providers-kubernetes#164