### PR TITLE
Added supported_catalog_types

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -39,4 +39,8 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   rescue KubeException => e
     raise MiqException::MiqProvisionError, "Unexpected Exception while creating project: #{e}"
   end
+
+  def supported_catalog_types
+    %w(generic_container_template).freeze
+  end
 end

--- a/spec/models/manageiq/providers/openshift/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager_spec.rb
@@ -1,0 +1,6 @@
+describe ManageIQ::Providers::Openshift::ContainerManager do
+  it "#supported_catalog_types" do
+    ems = FactoryGirl.create(:ems_openshift)
+    expect(ems.supported_catalog_types).to match_array(%w(generic_container_template))
+  end
+end


### PR DESCRIPTION
For Service Catalogs each provider manager needs to provide the catalog types it supports

Needed for https://github.com/ManageIQ/manageiq/pull/16559