### PR TITLE
Migrate model display names from locale/en.yml to plugin

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -43,4 +43,8 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   def supported_catalog_types
     %w(generic_container_template).freeze
   end
+
+  def self.display_name(number = 1)
+    n_('Container Provider (OpenShift)', 'Container Providers (OpenShift)', number)
+  end
 end

--- a/app/models/manageiq/providers/openshift/container_manager/container_template.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_template.rb
@@ -1,3 +1,7 @@
 class ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate < ManageIQ::Providers::ContainerManager::ContainerTemplate
   include ManageIQ::Providers::Kubernetes::ContainerManager::ContainerTemplateMixin
+
+  def self.display_name(number = 1)
+    n_('Container Template (OpenShift)', 'Container Templates (OpenShift)', number)
+  end
 end


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/ManageIQ/manageiq/pull/16596 where we want to migrate display model names from locale/en.yml into particular models, where we'll use standard gettext. Main goal here is to make this one aspect of our application pluggable.

Core PR: https://github.com/ManageIQ/manageiq/pull/16836