### PR TITLE
Add support for alert labels

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -14,6 +14,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   require_nested :Options
 
   include ManageIQ::Providers::Openshift::ContainerManager::Options
+  include ManageIQ::Providers::Kubernetes::ContainerManager::AlertLabels
 
   # Override HasMonitoringManagerMixin
   has_one :monitoring_manager,


### PR DESCRIPTION
This patch modifies the OpenShift provider so that it supports alert
labels. These labels will be extracted from the `full_data` stored in
the event that generated the alert.

Fixes https://bugzilla.redhat.com/1520125

Note that this pull request depends on ManageIQ/manageiq#16866,
which adds the `alert_labels` feature to the core.