### PR TITLE
Add test for service ports with same number different protocol

### DIFF
--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -356,6 +356,11 @@ shared_examples "openshift refresher VCR tests" do
     expect(@containersrv.container_project).to eq(ContainerProject.find_by(:name => "default"))
     expect(@containersrv.ext_management_system).to eq(@ems)
     expect(@containersrv.container_image_registry).to be_nil
+    expect(@containersrv.container_service_port_configs.pluck(:name, :protocol, :port)).to contain_exactly(
+      ["https", "TCP", 443],
+      ["dns", "UDP", 53],
+      ["dns-tcp", "TCP", 53]
+    )
   end
 
   def assert_specific_container_image_registry


### PR DESCRIPTION
A test for https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/89.

- [x] Depends on https://github.com/ManageIQ/manageiq/pull/16454 to fix classic refresh

    ```
       expected collection contained:  [["dns", "UDP", 53], ["dns-tcp", "TCP", 53], ["https", "TCP", 443]]
       actual collection contained:    [["dns-tcp", "TCP", 53], ["https", "TCP", 443]]
    ```
    passes with that PR.

Already passes in graph refresh, will ensure https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/212 and https://github.com/ManageIQ/manageiq-schema/pull/19 don't break it.

@Ladas please review.