### PR TITLE
Test :batch strategy with and without :use_ar_object

### DIFF
--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -538,26 +538,20 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
       expect(ManageIQ::Providers::Openshift::ContainerManager::RefreshParser).not_to receive(:ems_inv_to_hashes)
     end
 
-    context "with :default saver" do
-      before(:each) do
-        stub_settings_merge(
-          :ems_refresh => {:openshift => {:inventory_collections => {:saver_strategy => :default}}}
-        )
+    [
+      {:saver_strategy => :default},
+      {:saver_strategy => :batch, :use_ar_object => true},
+      {:saver_strategy => :batch, :use_ar_object => false}
+    ].each do |saver_options|
+      context "with #{saver_options}" do
+        before(:each) do
+          stub_settings_merge(
+            :ems_refresh => {:openshift => {:inventory_collections => saver_options}}
+          )
+        end
+
+        include_examples "openshift refresher VCR tests"
       end
-
-      # TODO: pending proper graph store_unused_images implemetation
-      include_examples "openshift refresher VCR tests"
-    end
-
-    context "with :batch saver" do
-      before(:each) do
-        stub_settings_merge(
-          :ems_refresh => {:openshift => {:inventory_collections => {:saver_strategy => :batch}}}
-        )
-      end
-
-      # TODO: pending proper graph store_unused_images implemetation
-      include_examples "openshift refresher VCR tests"
     end
   end
 end

--- a/spec/models/manageiq/providers/openshift/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -343,24 +343,20 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
       expect(ManageIQ::Providers::Openshift::ContainerManager::RefreshParser).not_to receive(:ems_inv_to_hashes)
     end
 
-    context "with :default saver" do
-      before(:each) do
-        stub_settings_merge(
-          :ems_refresh => {:openshift => {:inventory_collections => {:saver_strategy => :default}}}
-        )
+    [
+      {:saver_strategy => :default},
+      {:saver_strategy => :batch, :use_ar_object => true},
+      {:saver_strategy => :batch, :use_ar_object => false}
+    ].each do |saver_options|
+      context "with #{saver_options}" do
+        before(:each) do
+          stub_settings_merge(
+            :ems_refresh => {:openshift => {:inventory_collections => saver_options}}
+          )
+        end
+
+        include_examples "openshift refresher VCR targeted refresh tests"
       end
-
-      include_examples "openshift refresher VCR targeted refresh tests"
-    end
-
-    context "with :batch saver" do
-      before(:each) do
-        stub_settings_merge(
-          :ems_refresh => {:openshift => {:inventory_collections => {:saver_strategy => :batch}}}
-        )
-      end
-
-      include_examples "openshift refresher VCR targeted refresh tests"
     end
   end
 end


### PR DESCRIPTION
We hope to only use the fastest {:saver_strategy => :batch, :use_ar_object => false} in production, but testing all helps expose bugs in refresh...

Same as https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/235, can be merged independently.