### PR TITLE
Change saver_strategy value to String

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,7 +15,7 @@
     :refresh_interval: 15.minutes
     :inventory_object_refresh: true
     :inventory_collections:
-      :saver_strategy: :batch
+      :saver_strategy: batch
     :get_container_images: true
     :store_unused_images: true
 :workers:

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -539,9 +539,9 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     end
 
     [
-      {:saver_strategy => :default},
-      {:saver_strategy => :batch, :use_ar_object => true},
-      {:saver_strategy => :batch, :use_ar_object => false}
+      {:saver_strategy => "default"},
+      {:saver_strategy => "batch", :use_ar_object => true},
+      {:saver_strategy => "batch", :use_ar_object => false}
     ].each do |saver_options|
       context "with #{saver_options}" do
         before(:each) do

--- a/spec/models/manageiq/providers/openshift/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -344,9 +344,9 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
     end
 
     [
-      {:saver_strategy => :default},
-      {:saver_strategy => :batch, :use_ar_object => true},
-      {:saver_strategy => :batch, :use_ar_object => false}
+      {:saver_strategy => "default"},
+      {:saver_strategy => "batch", :use_ar_object => true},
+      {:saver_strategy => "batch", :use_ar_object => false}
     ].each do |saver_options|
       context "with #{saver_options}" do
         before(:each) do


### PR DESCRIPTION
Symbols in configuration values are problematic because Symbols do not roundtrip through JSON.  Since the API now exposes Settings, it's not possible to set Symbols as values.  The saver_strategy was fixed in ManageIQ/manageiq#17168 to support String values, and the next step is to remove all Symbols from the Settings.

ManageIQ/manageiq#17201
https://bugzilla.redhat.com/show_bug.cgi?id=1558031

@miq-bot add-labels bug, gaprindashvili/yes
@Fryguy @moolitayer please review.  This is similar to https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/246.