### PR TITLE
mapping.tag is a category Tag, calling .category is ill-defined

### DIFF
--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -105,7 +105,7 @@ shared_examples "openshift refresher VCR tests" do
 
     before(:each) do
       @key_route_label_mapping = FactoryGirl.create(:tag_mapping_with_category, :label_name => 'key-route-label')
-      @key_route_label_category = @key_route_label_mapping.tag.category
+      @key_route_label_category = @key_route_label_mapping.tag.classification
 
       mode = ENV['RECORD_VCR'] == 'before_deletions' ? :new_episodes : :none
       VCR.use_cassette("#{described_class.name.underscore}_before_deletions",


### PR DESCRIPTION
There are category/entry Tags, and category/entry Classifications.
```
                                   .parent
 category Classification "cat"   <----------   entry Classification "ent"
           |^                ^                        |^
       .tag||.classification  \_______________    .tag||.classification
           v|                     .category   \       v|
 category Tag /managed/cat                     entry Tag /managed/cat/ent
```
`.category` is supposed to get the "uncle", the category Classification from an *entry* Tag.

`mapping.tag` is a category Tag (for any-value mappings which are the kind we use).
Currently `.category` on a category Tag ("/managed/cat") happens to work same as `.classification`, but it's ill-defined and will stop working after https://github.com/ManageIQ/manageiq/pull/17418.

@miq-bot add-label test, technical debt
@kbrock @Fryguy please review