### PR TITLE
Persister: InventoryCollection building through add_collection()

### DIFF
--- a/app/models/manageiq/providers/openshift/inventory/persister.rb
+++ b/app/models/manageiq/providers/openshift/inventory/persister.rb
@@ -1,4 +1,16 @@
 class ManageIQ::Providers::Openshift::Inventory::Persister < ManagerRefresh::Inventory::Persister
   require_nested :TargetCollection
   require_nested :ContainerManager
+
+  def add_collection_directly(collection)
+    @collections[collection.name] = collection
+  end
+
+  # ManagerRefresh::InventoryCollection.inventory_object_attributes
+  # are not defined
+  def make_builder_settings(extra_settings = {})
+    opts = super
+    opts[:auto_inventory_attributes] = false
+    opts
+  end
 end

--- a/app/models/manageiq/providers/openshift/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/inventory/persister/container_manager.rb
@@ -1,13 +1,34 @@
 class ManageIQ::Providers::Openshift::Inventory::Persister::ContainerManager < ManageIQ::Providers::Openshift::Inventory::Persister
-  include ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollections
+  include ManageIQ::Providers::Kubernetes::Inventory::Persister::Definitions::ContainerCollections
 
   def initialize_inventory_collections
     super
+
+    initialize_container_inventory_collections
+
     # get_container_images=false mode is a stopgap to speed up refresh by reducing functionality.
     # Skipping these InventoryCollections (instead of returning empty ones)
     # to at least retain existing metadata if it was true and is now false.
     if options.get_container_images
-      initialize_custom_attributes_collections(@collections[:container_images], %w(labels docker_labels))
+      add_custom_attributes(:container_images, %w(labels docker_labels))
     end
+  end
+
+  protected
+
+  def targeted?
+    false
+  end
+
+  def strategy
+    nil
+  end
+
+  def shared_options
+    {
+      :strategy => strategy,
+      :targeted => targeted?,
+      :parent   => manager.presence
+    }
   end
 end

--- a/app/models/manageiq/providers/openshift/inventory/persister/target_collection.rb
+++ b/app/models/manageiq/providers/openshift/inventory/persister/target_collection.rb
@@ -1,16 +1,15 @@
 class ManageIQ::Providers::Openshift::Inventory::Persister::TargetCollection < ManageIQ::Providers::Openshift::Inventory::Persister::ContainerManager
-  def targeted
+  def targeted?
     false # TODO(lsmola) get ready for true, which means a proper targeted refresh. That will require more effort.
   end
 
   def shared_options
-    settings_options = options[:inventory_collections].try(:to_hash) || {}
-
-    settings_options.merge(
-      :targeted => targeted,
+    {
+      :targeted => targeted?,
       :complete => false, # For now, we want to a only create and update elements using watches data, delete events could
-      # probably set finished_at and deleted on dates, as an update based disconnect_inv.
+      # probably set finished_at and deleted_on dates, as an update based disconnect_inv.
       :strategy => :local_db_find_references, # By default no IC will be saved
-    )
+      :parent   => manager.presence
+    }
   end
 end


### PR DESCRIPTION
**Issue**: https://github.com/ManageIQ/manageiq/issues/17396
- [x] **depends on**: https://github.com/ManageIQ/manageiq/pull/17621
  - [x] **depends on**: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/265

**dependent**: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/266

New Interface for definition/creating InventoryCollection from persister.
Using add_collection() instead of add_inventory_collection() to build collections.

Builder classes are defined on core project, provider specific InventoryCollections specified in concerns