### PR TITLE
Fix a reference to ManagerRefresh::Inventory

### DIFF
--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_inventory_object_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_inventory_object_spec.rb
@@ -33,7 +33,7 @@ shared_examples "openshift refresher VCR tests" do
       collector = ManageIQ::Providers::Openshift::Inventory::Collector::ContainerManager.new(@ems, @ems)
       persister = ManageIQ::Providers::Openshift::Inventory::Persister::ContainerManager.new(@ems)
 
-      inventory = ::ManagerRefresh::Inventory.new(
+      inventory = ::ManageIQ::Providers::Inventory.new(
         persister,
         collector,
         [ManageIQ::Providers::Openshift::Inventory::Parser::ContainerManager.new]


### PR DESCRIPTION
This was merged after the PR that renamed all ManagerRefresh::Inventory
to ManageIQ::Providers::Inventory