### PR TITLE
[GAPRINDASHVILI] Fix specs failing on a missing zone

### DIFF
--- a/spec/factories/ext_management_system.rb
+++ b/spec/factories/ext_management_system.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :ems_openshift_with_zone, :parent => :ems_openshift do
+    zone do
+      _guid, _server, zone = EvmSpecHelper.create_guid_miq_server_zone
+      zone
+    end
+  end
+end

--- a/spec/models/manageiq/providers/openshift/container_manager/container_template_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/container_template_spec.rb
@@ -3,7 +3,7 @@ describe ContainerTemplate do
     hostname = 'host.example.com'
     token = 'theToken'
     FactoryGirl.create(
-      :ems_openshift,
+      :ems_openshift_with_zone,
       :name                      => 'OpenShiftProvider',
       :connection_configurations => [{:endpoint       => {:role     => :default,
                                                           :hostname => hostname,
@@ -18,10 +18,6 @@ describe ContainerTemplate do
                                                           :auth_key => token,
                                                           :userid   => "_"}}]
     )
-  end
-
-  before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
   end
 
   it "instantiate a template with parameters and object labels" do

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -5,13 +5,12 @@ shared_examples "openshift refresher VCR tests" do
   let(:images_managed_by_openshift_count) { 32 } # only images from /oapi/v1/images
 
   before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     # env vars for easier VCR recording, see test_objects_record.sh
     hostname = ENV["OPENSHIFT_MASTER_HOST"] || "host.example.com"
     token = ENV["OPENSHIFT_MANAGEMENT_ADMIN_TOKEN"] || "theToken"
 
     @ems = FactoryGirl.create(
-      :ems_openshift,
+      :ems_openshift_with_zone,
       :name                      => "OpenShiftProvider",
       :connection_configurations => [{:endpoint       => {:role              => :default,
                                                           :hostname          => hostname,

--- a/spec/models/manageiq/providers/openshift/container_manager/targeted_refresh/targeted_refresh_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/targeted_refresh/targeted_refresh_spec.rb
@@ -1,13 +1,12 @@
 # instantiated at the end
 shared_examples "openshift refresher VCR targeted refresh tests" do
   before(:each) do
-    allow(MiqServer).to receive(:my_zone).and_return("default")
     hostname          = 'host.example.com'
     token             = 'theToken'
     hawkular_hostname = 'host.example.com'
 
     @ems = FactoryGirl.create(
-      :ems_openshift,
+      :ems_openshift_with_zone,
       :name                      => 'OpenshiftProvider',
       :connection_configurations => [{:endpoint       => {:role       => :default,
                                                           :hostname   => hostname,


### PR DESCRIPTION
Partial backport of #114 (minus file that didn't exist on gaprindashvili)

Stubbing MiqServer.my_zone to return a dummy string was affecting the zone with which events were added to MiqQueue, which broke now that MiqQueue requires a real zone (https://github.com/ManageIQ/manageiq/pull/18068#issuecomment-435087412).

@agrare @Ladas @simaishi please review