### PR TITLE
Kubeclient v3.1.0 removed Common::WatchClient

### DIFF
--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_inventory_object_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_inventory_object_spec.rb
@@ -88,7 +88,7 @@ shared_examples "openshift refresher VCR tests" do
     # NOTE: this object is from the full refresh, I have deleted most of the
     # other metadata/spec/status to keep the cruft down since we're only parsing
     # the uid.
-    notice = Kubeclient::Common::WatchNotice.new(
+    notice = Kubeclient::Resource.new(
       :type   => "DELETED",
       :object => {
         :kind       => "Pod",


### PR DESCRIPTION
https://github.com/abonas/kubeclient/pull/299 removed the
Kubeclient::Common::WatchNotice class, now watches just return
Kubeclient::Resource objects.