### PR TITLE
Only allow for graph refresh

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_parser.rb
@@ -1,20 +1,6 @@
 module ManageIQ::Providers
   module Openshift
     class ContainerManager::RefreshParser < ManageIQ::Providers::Kubernetes::ContainerManager::RefreshParser
-      def ems_inv_to_hashes(inventory, options = Config::Options.new)
-        super(inventory, options)
-        merge_projects_into_namespaces(inventory)
-        get_routes(inventory)
-        get_builds(inventory)
-        get_build_pods(inventory)
-        get_templates(inventory)
-        get_or_merge_openshift_images(inventory) if options.get_container_images
-        EmsRefresh.log_inv_debug_trace(@data, "data:")
-
-        # Returning a hash triggers save_inventory_container code path.
-        @data
-      end
-
       def persister_class
         ManageIQ::Providers::Openshift::Inventory::Persister::ContainerManager
       end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -1,4 +1,3 @@
-# instantiated at the end, for both classical and graph refresh
 shared_examples "openshift refresher VCR tests" do
   let(:all_images_count) { 40 } # including /oapi/v1/images data
   let(:pod_images_count) { 12 } # only images mentioned by pods
@@ -513,41 +512,19 @@ shared_examples "openshift refresher VCR tests" do
 end
 
 describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
-  context "classical refresh" do
-    before(:each) do
-      stub_settings_merge(
-        :ems_refresh => {:openshift => {:inventory_object_refresh => false}}
-      )
-
-      expect(ManageIQ::Providers::Openshift::ContainerManager::RefreshParser).not_to receive(:ems_inv_to_inv_collections)
-    end
-
-    include_examples "openshift refresher VCR tests"
-  end
-
-  context "graph refresh" do
-    before(:each) do
-      stub_settings_merge(
-        :ems_refresh => {:openshift => {:inventory_object_refresh => true}}
-      )
-
-      expect(ManageIQ::Providers::Openshift::ContainerManager::RefreshParser).not_to receive(:ems_inv_to_hashes)
-    end
-
-    [
-      {:saver_strategy => "default"},
-      {:saver_strategy => "batch", :use_ar_object => true},
-      {:saver_strategy => "batch", :use_ar_object => false}
-    ].each do |saver_options|
-      context "with #{saver_options}" do
-        before(:each) do
-          stub_settings_merge(
-            :ems_refresh => {:openshift => {:inventory_collections => saver_options}}
-          )
-        end
-
-        include_examples "openshift refresher VCR tests"
+  [
+    {:saver_strategy => "default"},
+    {:saver_strategy => "batch", :use_ar_object => true},
+    {:saver_strategy => "batch", :use_ar_object => false}
+  ].each do |saver_options|
+    context "with #{saver_options}" do
+      before(:each) do
+        stub_settings_merge(
+          :ems_refresh => {:openshift => {:inventory_collections => saver_options}}
+        )
       end
+
+      include_examples "openshift refresher VCR tests"
     end
   end
 end


### PR DESCRIPTION
Disable the ability to switch the refresh type and only support graph
refresh.

Related to: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/340