### PR TITLE
Remove unused InventoryCollectorWorker

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -5,7 +5,6 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   require_nested :ContainerTemplate
   require_nested :EventCatcher
   require_nested :EventParser
-  require_nested :InventoryCollectorWorker
   require_nested :MetricsCollectorWorker
   require_nested :OrchestrationStack
   require_nested :RefreshParser

--- a/app/models/manageiq/providers/openshift/container_manager/inventory_collector_worker.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/inventory_collector_worker.rb
@@ -1,8 +1,0 @@
-class ManageIQ::Providers::Openshift::ContainerManager::InventoryCollectorWorker < ManageIQ::Providers::BaseManager::InventoryCollectorWorker
-  require_nested :Runner
-
-  def self.has_required_role?
-    return false unless Settings.fetch_path(:ems_refresh, ems_class.ems_type.to_sym, :inventory_object_refresh)
-    super
-  end
-end

--- a/app/models/manageiq/providers/openshift/container_manager/inventory_collector_worker/runner.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/inventory_collector_worker/runner.rb
@@ -1,3 +1,0 @@
-class ManageIQ::Providers::Openshift::ContainerManager::InventoryCollectorWorker::Runner < ManageIQ::Providers::BaseManager::InventoryCollectorWorker::Runner
-  include ManageIQ::Providers::Kubernetes::ContainerManager::InventoryCollectorMixin
-end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -27,11 +27,6 @@
         :poll: 1.seconds
       :event_catcher_prometheus:
         :poll: 20.seconds
-    :ems_inventory_collector_worker:
-      :ems_inventory_collector_worker_openshift:
-        :deleted_notices_only: true
-        :disabled: true
-        :watch_thread_shutdown_timeout: 10.seconds
     :queue_worker_base:
         :ems_metrics_collector_worker:
           :ems_metrics_collector_worker_openshift: {}


### PR DESCRIPTION
The InventoryCollectorWorker was an experimental streaming refresh
worker for kubernetes/openshift but was never used.