### PR TITLE
Add default_port needed for params_for_create

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -33,6 +33,10 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
   end
 
+  def self.default_port
+    DEFAULT_PORT
+  end
+
   def create_project(project)
     connect.create_project_request(project)
   rescue KubeException => e


### PR DESCRIPTION
Use the params_for_create and verify_credential methods from ContainerManagerMixin in kubernetes, just need to define the default_port

Depends on: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/341

https://github.com/ManageIQ/manageiq/issues/18818