### PR TITLE
Remove settings inventory refresh

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -43,6 +43,10 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
     raise MiqException::MiqProvisionError, "Unexpected Exception while creating project: #{e}"
   end
 
+  def inventory_object_refresh?
+    true
+  end
+
   def supported_catalog_types
     %w(generic_container_template).freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,7 +15,6 @@
     :refresh_interval: 15.minutes
     :streaming_refresh: false
     :chunk_size: 1_000
-    :inventory_object_refresh: true
     :inventory_collections:
       :saver_strategy: batch
     :get_container_images: true


### PR DESCRIPTION
Remove inventory_object_refresh from settings as part of the effort to remove the old legacy EmsRefresh and save_inventory refresh code.