### PR TITLE
Pass api_group when creating a project

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   end
 
   def create_project(project)
-    connect.create_project_request(project)
+    connect(:api_group => "project.openshift.io").create_project_request(project)
   rescue KubeException => e
     raise MiqException::MiqProvisionError, "Unexpected Exception while creating project: #{e}"
   end


### PR DESCRIPTION
Fix `#create_project` on openshift 4 by passing in the API Group

Follow-up to https://github.com/ManageIQ/manageiq-providers-openshift/issues/139