### PR TITLE
Fix instantiate container template

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/container_template.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_template.rb
@@ -30,7 +30,7 @@ class ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate < Mana
   end
 
   def create_object(obj, project)
-    obj = obj.symbolize_keys
+    obj = obj.deep_symbolize_keys
     obj[:metadata][:namespace] = project
     method_name = "create_#{obj[:kind].underscore}"
     begin

--- a/app/models/manageiq/providers/openshift/container_manager/container_template.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_template.rb
@@ -34,7 +34,8 @@ class ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate < Mana
     obj[:metadata][:namespace] = project
     method_name = "create_#{obj[:kind].underscore}"
     begin
-      ext_management_system.connect_client(obj[:apiVersion], method_name).send(method_name, obj)
+      client = ext_management_system.connect_client(obj[:kind], obj[:apiVersion], method_name)
+      client.send(method_name, obj)
     rescue KubeException => e
       rollback_objects(@created_objects)
       raise MiqException::MiqProvisionError, "Unexpected Exception while creating object: #{e}"
@@ -50,9 +51,8 @@ class ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate < Mana
   def rollback_object(obj)
     method_name = "delete_#{obj[:kind].underscore}"
     begin
-      ext_management_system.connect_client(obj[:apiVersion], method_name).send(method_name,
-                                                                               obj[:metadata][:name],
-                                                                               obj[:metadata][:namespace])
+      client = ext_management_system.connect_client(obj[:kind], obj[:apiVersion], method_name)
+      client.send(method_name, obj[:metadata][:name], obj[:metadata][:namespace])
     rescue KubeException => e
       _log.error("Unexpected Exception while deleting object: #{e}")
     end

--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -51,7 +51,7 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
     end
   end
 
-  def connect_client(api_version, method_name)
+  def connect_client(kind, api_version, method_name)
     @clients ||= {}
     api, version = api_version.split('/', 2)
     if version

--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -57,11 +57,16 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
     if version
       @clients[api_version] ||= connect(:service => 'kubernetes', :version => version, :path => '/apis/' + api)
     else
-      openshift = 'oapi' + api_version
-      kubernetes = 'api' + api_version
-      @clients[openshift] ||= connect(:version => api_version)
-      @clients[kubernetes] ||= connect(:service => 'kubernetes', :version => api_version)
-      @clients[openshift].respond_to?(method_name) ? @clients[openshift] : @clients[kubernetes]
+      # If we're given an OpenShift object lookup its v4 API Group
+      api_group = api_group_for_kind(kind)
+      path      = api_group ? "/apps/#{api_group}" : "/oapi"
+
+      openshift_client_key  = File.join(path, api_version)
+      kubernetes_client_key = File.join("/api", api_version)
+
+      @clients[openshift_client_key] ||= connect(:api_group => api_group, :version => api_version)
+      @clients[kubernetes_client_key] ||= connect(:service => 'kubernetes', :version => api_version)
+      @clients[openshift_client_key].respond_to?(method_name) ? @clients[openshift_client_key] : @clients[kubernetes_client_key]
     end
   end
 
@@ -75,5 +80,23 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
 
   def external_logging_path
     '/'
+  end
+
+  def api_group_for_kind(kind)
+    # TODO: is there a more general way of detecting this?
+    case kind
+    when "BuildConfig", "Build"
+      "build.openshift.io"
+    when "DeploymentConfig"
+      "apps.openshift.io"
+    when "Image"
+      "image.openshift.io"
+    when "Project"
+      "project.openshift.io"
+    when "Route"
+      "route.openshift.io"
+    when "Template"
+      "template.openshift.io"
+    end
   end
 end


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-providers-openshift/issues/139#issuecomment-611938172

This most likely wasn't working for a long time, `obj.symbolize_keys[:metadata][:namespace]` was failing because it was at `obj[:metadata]["namespace"]` 