### PR TITLE
Container routes always belong to the EMS

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -6,10 +6,6 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
   DEFAULT_PORT = 8443
   DEFAULT_EXTERNAL_LOGGING_ROUTE_NAME = "logging-kibana-ops".freeze
 
-  included do
-    has_many :container_routes, :foreign_key => :ems_id, :dependent => :destroy
-  end
-
   # This is the API version that we use and support throughout the entire code
   # (parsers, events, etc.). It should be explicitly selected here and not
   # decided by the user nor out of control in the defaults of openshift gem


### PR DESCRIPTION
ContainerRoutes should belong to the EMS for all ContainerManagers not just Openshift

Depends on: https://github.com/ManageIQ/manageiq/pull/20126
Cross Repo Test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/118