### PR TITLE
Add a method to detect the metrics service hostname

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -84,6 +84,17 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
     end
   end
 
+  OPENSHIFT_ROUTES = {
+    "hawkular"          => %w[hawkular-metrics openshift-infra],
+    "prometheus"        => %w[prometheus openshift-metrics],
+    "prometheus_alerts" => %w[alerts openshift-metrics]
+  }.freeze
+
+  def hostname_for_service(service_type)
+    routes = connect(:service => "openshift", :api_group => "route.openshift.io")
+    routes.get_route(*OPENSHIFT_ROUTES[service_type])&.spec&.host
+  end
+
   def external_logging_route_name
     DEFAULT_EXTERNAL_LOGGING_ROUTE_NAME
   end


### PR DESCRIPTION
Move this method out of the UI and into the provider

https://github.com/ManageIQ/manageiq-ui-classic/pull/7043