### PR TITLE
V4 openshift-monitoring/alertmanager-main isn't the PrometheusAlertBuffer

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager_mixin.rb
+++ b/app/models/manageiq/providers/openshift/container_manager_mixin.rb
@@ -112,8 +112,7 @@ module ManageIQ::Providers::Openshift::ContainerManagerMixin
         "prometheus_alerts" => %w[alerts openshift-metrics]
       },
       "v4" => {
-        "prometheus"        => %w[prometheus-k8s openshift-monitoring],
-        "prometheus_alerts" => %w[alertmanager-main openshift-monitoring]
+        "prometheus" => %w[prometheus-k8s openshift-monitoring],
       }
     }
 


### PR DESCRIPTION
This service isn't the same prometheus alert buffer that exposes the /topic/alerts API that we need for the MonitoringManager.

It might be possible to configure OCPv4 with Prometheus Alert Buffer but it isn't default so we shouldn't auto-detect it.

Fixes https://github.com/ManageIQ/manageiq-providers-openshift/issues/177