### PR TITLE
[JANSA] Disable streaming refresh by default

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,7 +13,7 @@
 :ems_refresh:
   :openshift:
     :refresh_interval: 15.minutes
-    :streaming_refresh: true
+    :streaming_refresh: false
     :chunk_size: 1_000
     :inventory_object_refresh: true
     :inventory_collections:


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-providers-openshift/pull/169 backported cleanly but we wanted to disable this by default (https://github.com/ManageIQ/manageiq-providers-kubernetes/commit/a11a3a86f3600411126017c7775eb15470b57385 on the kubernetes side)