### PR TITLE
Add methods that can be overridden easily to ContainerTemplate

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -37,11 +37,11 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Co
   end
 
   def v3?
-    api_version.to_s =~ /3\..*/
+    api_version.to_s.split(".").first == "3"
   end
 
   def v4?
-    api_version.to_s =~ /4\..*/
+    api_version.to_s.split(".").first == "4"
   end
 
   def create_project(project)

--- a/app/models/manageiq/providers/openshift/container_manager/container_template.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_template.rb
@@ -3,7 +3,17 @@ autoload(:KubeException, 'kubeclient')
 class ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate < ManageIQ::Providers::ContainerManager::ContainerTemplate
   include ManageIQ::Providers::Kubernetes::ContainerManager::EntitiesMapping
 
-  supports :instantiate
+  def instantiate_supported?
+    true
+  end
+
+  def instantiate_unsupported_reason
+    nil
+  end
+
+  supports :instantiate do
+    unsupported_reason_add(:instantiate, instantiate_unsupported_reason) unless instantiate_supported?
+  end
 
   def instantiate(params, project = nil, labels = nil)
     project ||= container_project.name

--- a/spec/models/manageiq/providers/openshift/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager_spec.rb
@@ -3,4 +3,40 @@ describe ManageIQ::Providers::Openshift::ContainerManager do
     ems = FactoryBot.create(:ems_openshift)
     expect(ems.catalog_types).to include("generic_container_template")
   end
+
+  describe "#v3?" do
+    context "with a v3 cluster" do
+      let(:ems) { FactoryBot.create(:ems_openshift, :api_version => "3.11.0") }
+
+      it "returns true" do
+        expect(ems.v3?).to be_truthy
+      end
+    end
+
+    context "with a v4 cluster" do
+      let(:ems) { FactoryBot.create(:ems_openshift, :api_version => "4.3.0") }
+
+      it "returns false" do
+        expect(ems.v3?).to be_falsey
+      end
+    end
+  end
+
+  describe "#v4?" do
+    context "with a v3 cluster" do
+      let(:ems) { FactoryBot.create(:ems_openshift, :api_version => "3.11.0") }
+
+      it "returns false" do
+        expect(ems.v4?).to be_falsey
+      end
+    end
+
+    context "with a v4 cluster" do
+      let(:ems) { FactoryBot.create(:ems_openshift, :api_version => "4.3.0") }
+
+      it "returns true" do
+        expect(ems.v4?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add methods that can be easily overridden by an initializer to the 
container templates supports :instantiation check.