### PR TITLE
Subclassed provider classes should mark the parent as a leaf class 

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -1,3 +1,5 @@
+ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
   DEFAULT_PORT = 8443
   DEFAULT_EXTERNAL_LOGGING_ROUTE_NAME = "logging-kibana-ops".freeze

--- a/app/models/manageiq/providers/openshift/container_manager/container.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::Container.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Openshift::ContainerManager::Container < ManageIQ::Providers::Kubernetes::ContainerManager::Container
 end

--- a/app/models/manageiq/providers/openshift/container_manager/container_group.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_group.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Openshift::ContainerManager::ContainerGroup < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerGroup
 end

--- a/app/models/manageiq/providers/openshift/container_manager/container_node.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_node.rb
@@ -1,2 +1,4 @@
+ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode.include(ActsAsStiLeafClass)
+
 class ManageIQ::Providers::Openshift::ContainerManager::ContainerNode < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerNode
 end

--- a/app/models/manageiq/providers/openshift/monitoring_manager.rb
+++ b/app/models/manageiq/providers/openshift/monitoring_manager.rb
@@ -1,3 +1,5 @@
+ManageIQ::Providers::Kubernetes::MonitoringManager.include(ActsAsStiLeafClass)
+
 module ManageIQ::Providers
   class Openshift::MonitoringManager < ManageIQ::Providers::Kubernetes::MonitoringManager
     require_nested :EventCatcher

--- a/app/models/manageiq/providers/openshift/monitoring_manager.rb
+++ b/app/models/manageiq/providers/openshift/monitoring_manager.rb
@@ -1,24 +1,22 @@
 ManageIQ::Providers::Kubernetes::MonitoringManager.include(ActsAsStiLeafClass)
 
-module ManageIQ::Providers
-  class Openshift::MonitoringManager < ManageIQ::Providers::Kubernetes::MonitoringManager
-    require_nested :EventCatcher
+class ManageIQ::Providers::Openshift::MonitoringManager < ManageIQ::Providers::Kubernetes::MonitoringManager
+  require_nested :EventCatcher
 
-    belongs_to :parent_manager,
-               :foreign_key => :parent_ems_id,
-               :class_name  => "ManageIQ::Providers::Openshift::ContainerManager",
-               :inverse_of  => :monitoring_manager
+  belongs_to :parent_manager,
+             :foreign_key => :parent_ems_id,
+             :class_name  => "ManageIQ::Providers::Openshift::ContainerManager",
+             :inverse_of  => :monitoring_manager
 
-    def self.ems_type
-      @ems_type ||= "openshift_monitor".freeze
-    end
+  def self.ems_type
+    @ems_type ||= "openshift_monitor".freeze
+  end
 
-    def self.description
-      @description ||= "Openshift Monitor".freeze
-    end
+  def self.description
+    @description ||= "Openshift Monitor".freeze
+  end
 
-    def self.event_monitor_class
-      ManageIQ::Providers::Openshift::MonitoringManager::EventCatcher
-    end
+  def self.event_monitor_class
+    ManageIQ::Providers::Openshift::MonitoringManager::EventCatcher
   end
 end


### PR DESCRIPTION
- [ ] Depends on https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/433

@agrare Please review.