### PR TITLE
Add missing require_nested Service*

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -15,6 +15,9 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Ku
   require_nested :OrchestrationStack
   require_nested :RefreshWorker
   require_nested :Refresher
+  require_nested :ServiceInstance
+  require_nested :ServiceOffering
+  require_nested :ServiceParametersSet
   require_nested :Options
 
   include ManageIQ::Providers::Openshift::ContainerManager::Options


### PR DESCRIPTION
This causes refresh to fail with `expected service_instances to be found subclassed as ManageIQ::Providers::Openshift::ContainerManager::ServiceInstance, but instead found ServiceInstance`