### PR TITLE
[WIP] Split up "pod" images and managed container images

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -11,6 +11,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Ku
   require_nested :ContainerTemplate
   require_nested :EventCatcher
   require_nested :EventParser
+  require_nested :ManagedContainerImage
   require_nested :MetricsCollectorWorker
   require_nested :OrchestrationStack
   require_nested :RefreshWorker

--- a/app/models/manageiq/providers/openshift/container_manager/container_image.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_image.rb
@@ -2,4 +2,9 @@ ManageIQ::Providers::Kubernetes::ContainerManager::ContainerImage.include(ActsAs
 
 class ManageIQ::Providers::Openshift::ContainerManager::ContainerImage < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerImage
   supports_not :capture
+
+  def self.disconnect_inv(ids)
+    _log.info "Disconnecting Images [#{ids}]"
+    base_class.where(:id => ids).update_all(:container_image_registry_id => nil, :deleted_on => Time.now.utc)
+  end
 end

--- a/app/models/manageiq/providers/openshift/container_manager/container_image.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_image.rb
@@ -1,41 +1,5 @@
-class ManageIQ::Providers::Openshift::ContainerManager::ContainerImage < ContainerImage
-  def annotate_image(annotations)
-    ext_management_system.annotate(
-      "image",
-      digest,
-      annotations
-    )
-  end
+ManageIQ::Providers::Kubernetes::ContainerManager::ContainerImage.include(ActsAsStiLeafClass)
 
-  def openscap_summary
-    failed_rules = openscap_rule_results.where(:result => "fail").group(:severity).count
-    [[['High'], 'Critical', 3],
-     [['Medium'], 'Important', 2],
-     [['Low'], 'Medium', 1],
-     [['Info', 'Unknown'], 'Low', 0]].collect do |severities, label, index|
-      {
-        :label         => label,
-        :severityIndex => index,
-        :data          => failed_rules.select { |sev| severities.include?(sev) }.values.sum
-      }
-    end
-  end
-
-  def security_quality_annotation(compliant)
-    {"quality.images.openshift.io/vulnerability.openscap" => {
-      :name        => "ManageIQ",
-      :timestamp   => Time.now.utc.to_i,
-      :description => "OpenSCAP Score",
-      :reference   => "",
-      :compliant   => compliant,
-      :summary     => openscap_summary
-    }.to_json}
-  end
-
-  def annotate_scan_policy_results(causing_policy, compliant)
-    annotate_image({
-      "security.manageiq.org/#{compliant ? "successful" : "failed"}-policy" => causing_policy,
-      "images.openshift.io/deny-execution"  => (!compliant).to_s
-    }.merge!(security_quality_annotation(compliant)))
-  end
+class ManageIQ::Providers::Openshift::ContainerManager::ContainerImage < ManageIQ::Providers::Kubernetes::ContainerManager::ContainerImage
+  supports_not :capture
 end

--- a/app/models/manageiq/providers/openshift/container_manager/managed_container_image.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/managed_container_image.rb
@@ -1,0 +1,43 @@
+class ManageIQ::Providers::Openshift::ContainerManager::ManagedContainerImage < ManageIQ::Providers::Openshift::ContainerManager::ContainerImage
+  supports :capture
+
+  def annotate_image(annotations)
+    ext_management_system.annotate(
+      "image",
+      digest,
+      annotations
+    )
+  end
+
+  def openscap_summary
+    failed_rules = openscap_rule_results.where(:result => "fail").group(:severity).count
+    [[['High'], 'Critical', 3],
+     [['Medium'], 'Important', 2],
+     [['Low'], 'Medium', 1],
+     [['Info', 'Unknown'], 'Low', 0]].collect do |severities, label, index|
+      {
+        :label         => label,
+        :severityIndex => index,
+        :data          => failed_rules.select { |sev| severities.include?(sev) }.values.sum
+      }
+    end
+  end
+
+  def security_quality_annotation(compliant)
+    {"quality.images.openshift.io/vulnerability.openscap" => {
+      :name        => "ManageIQ",
+      :timestamp   => Time.now.utc.to_i,
+      :description => "OpenSCAP Score",
+      :reference   => "",
+      :compliant   => compliant,
+      :summary     => openscap_summary
+    }.to_json}
+  end
+
+  def annotate_scan_policy_results(causing_policy, compliant)
+    annotate_image({
+      "security.manageiq.org/#{compliant ? "successful" : "failed"}-policy" => causing_policy,
+      "images.openshift.io/deny-execution"  => (!compliant).to_s
+    }.merge!(security_quality_annotation(compliant)))
+  end
+end

--- a/app/models/manageiq/providers/openshift/inventory/parser/openshift_parser_mixin.rb
+++ b/app/models/manageiq/providers/openshift/inventory/parser/openshift_parser_mixin.rb
@@ -221,7 +221,7 @@ module ManageIQ::Providers::Openshift::Inventory::Parser::OpenshiftParserMixin
       :ref => "#{ContainerImage::DOCKER_PULLABLE_PREFIX}#{id}",
     }
 
-    new_result[:type] = 'ManageIQ::Providers::Openshift::ContainerManager::ContainerImage'
+    new_result[:type] = 'ManageIQ::Providers::Openshift::ContainerManager::ManagedContainerImage'
 
     if openshift_image[:dockerImageManifest].present?
       begin

--- a/spec/factories/container_image.rb
+++ b/spec/factories/container_image.rb
@@ -2,4 +2,6 @@ FactoryBot.define do
   factory :openshift_container_image, :class => "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage" do
     sequence(:name) { |n| "openshift_container_image_#{seq_padded_for_sorting(n)}" }
   end
+
+  factory :openshift_managed_container_image, :class => "ManageIQ::Providers::Openshift::ContainerManager::ManagedContainerImage", :parent => :openshift_container_image
 end

--- a/spec/models/manageiq/providers/openshift/container_manager/container_image_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/container_image_spec.rb
@@ -1,33 +1,25 @@
 describe ManageIQ::Providers::Openshift::ContainerManager::ContainerImage do
   context "#security_quality_annotation" do
-    let(:openshift_image_type) { "ManageIQ::Providers::Openshift::ContainerManager::ContainerImage" }
-    let(:container_image) do
-      FactoryBot.create(:openshift_container_image,
-                         :type => openshift_image_type)
-    end
-    let(:blob) do
-      FactoryBot.create(:binary_blob,
-                         :binary => "blah",
-                         :name   => "test_blob")
-    end
+    let(:container_image)      { FactoryBot.create(:openshift_managed_container_image) }
+    let(:blob)                 { FactoryBot.create(:binary_blob, :binary => "blah", :name => "test_blob") }
     let(:scan_result) do
       FactoryBot.create(:openscap_result_skip_callback,
-                         :binary_blob        => blob,
-                         :resource_id        => container_image.id,
-                         :resource_type      => openshift_image_type,
-                         :container_image_id => container_image.id)
+                        :binary_blob        => blob,
+                        :resource_id        => container_image.id,
+                        :resource_type      => container_image.type,
+                        :container_image_id => container_image.id)
     end
     let(:successful_rule) do
       FactoryBot.create(:openscap_rule_result,
-                         :openscap_result_id => scan_result.id,
-                         :severity           => "High",
-                         :result             => "success")
+                        :openscap_result_id => scan_result.id,
+                        :severity           => "High",
+                        :result             => "success")
     end
     let(:failed_rule) do
       FactoryBot.create(:openscap_rule_result,
-                         :openscap_result_id => scan_result.id,
-                         :severity           => "Medium",
-                         :result             => "fail")
+                        :openscap_result_id => scan_result.id,
+                        :severity           => "Medium",
+                        :result             => "fail")
     end
 
     before :each do

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -232,7 +232,7 @@ shared_examples "openshift refresher VCR tests" do
     expect(ContainerTemplate.count).to eq(26)
     expect(ContainerImage.count).to eq(all_images_count)
     expect(ContainerImage.joins(:containers).distinct.count).to eq(pod_images_count)
-    expect(ManageIQ::Providers::Openshift::ContainerManager::ContainerImage.count).to eq(images_managed_by_openshift_count)
+    expect(ManageIQ::Providers::Openshift::ContainerManager::ManagedContainerImage.count).to eq(images_managed_by_openshift_count)
   end
 
   def assert_ems


### PR DESCRIPTION
Container Images on OpenShift come from two different sources, the first is from the `/apis/image.openshift.io/v1` API and the second is from pods.  If a pod is using an image which isn't in the `/apis/image.openshift.io/v1` we create a new "unmanaged" container image record.  Currently these are of the type `::ContainerImage`.

Cross-repo Tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/632

Depends on:
- [ ] https://github.com/ManageIQ/manageiq/pull/21828
- [ ] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/463