### PR TITLE
make supports :external_logging simple

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -31,6 +31,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Ku
 
   supports :catalog
   supports :create
+  supports :external_logging
 
   def self.ems_type
     @ems_type ||= "openshift".freeze


### PR DESCRIPTION
No reason to use responds_to or complicated supports block.
just using a standard supports/supports_not

We were going to introduce special syntax for the supports.
This is easier to read and understand