### PR TITLE
Replace lazy_find_by with simple lazy_find

### DIFF
--- a/app/models/manageiq/providers/openshift/inventory/parser/openshift_parser_mixin.rb
+++ b/app/models/manageiq/providers/openshift/inventory/parser/openshift_parser_mixin.rb
@@ -88,12 +88,12 @@ module ManageIQ::Providers::Openshift::Inventory::Parser::OpenshiftParserMixin
   def lazy_find_service(hash)
     return nil if hash.nil?
     search = {:container_project => lazy_find_project(:name => hash[:namespace]), :name => hash[:name]}
-    persister.container_services.lazy_find_by(search, :ref => :by_container_project_and_name)
+    persister.container_services.lazy_find(search, :ref => :by_container_project_and_name)
   end
 
   def lazy_find_build(hash)
     return nil if hash.nil?
-    persister.container_builds.lazy_find_by(hash, :ref => :by_namespace_and_name)
+    persister.container_builds.lazy_find(hash, :ref => :by_namespace_and_name)
   end
 
   ## Shared parsing methods


### PR DESCRIPTION
The lazy_find_by method is no different from the lazy_find method now and will be removed in an upcoming inventory_refresh release