### PR TITLE
Support ruby 3

### DIFF
--- a/app/models/manageiq/providers/openshift/inventory/parser/openshift_parser_mixin.rb
+++ b/app/models/manageiq/providers/openshift/inventory/parser/openshift_parser_mixin.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers::Openshift::Inventory::Parser::OpenshiftParserMixin
       ref = openshift_result.delete(:ref)
 
       # This hides @data_index reading and writing.
-      parse_container_image(id, ref, opts)&.merge!(openshift_result)
+      parse_container_image(id, ref, **opts)&.merge!(openshift_result)
     end
   end
 

--- a/manageiq-providers-openshift.gemspec
+++ b/manageiq-providers-openshift.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "manageiq-providers-kubernetes", "~> 0.1.0"
 
   spec.add_development_dependency "manageiq-style"
-  spec.add_development_dependency "recursive-open-struct", "~> 1.0.0"
+  spec.add_development_dependency "recursive-open-struct", "~> 1.1"
   spec.add_development_dependency "simplecov", ">= 0.21.2"
 end


### PR DESCRIPTION
parse_container_image accepts kwargs, ruby 3 requires it be explicit. Loosen recursive-open-struct to allow ruby 3 supported kubeclient.