### PR TITLE
Fix MetricsCollectorWorker running with invalid creds

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/metrics_collector_worker.rb
@@ -7,5 +7,14 @@ module ManageIQ::Providers
     def friendly_name
       @friendly_name ||= "C&U Metrics Collector for OpenShift"
     end
+
+    # Override PerEmsTypeWorkerMixin.all_valid_ems_in_zone to limit metrics collection
+    def self.all_ems_in_zone
+      super.select do |ems|
+        ems.supports?(:metrics).tap do |supported|
+          _log.info("Skipping [#{ems.name}] since it has no metrics endpoint") unless supported
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This worker wasn't inheriting from Kubernetes' MetricsCollectorWorker class thus didn't pull in the code to not start up if there are no Openshift providers with a metrics endpoint.

Depends:
- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/476