### PR TITLE
Openshift v4 has same default port as k8s

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -1,7 +1,6 @@
 ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
-  DEFAULT_PORT = 8443
   DEFAULT_EXTERNAL_LOGGING_ROUTE_NAME = "logging-kibana-ops".freeze
 
   require_nested :Container
@@ -43,10 +42,6 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Ku
 
   def self.event_monitor_class
     ManageIQ::Providers::Openshift::ContainerManager::EventCatcher
-  end
-
-  def self.default_port
-    DEFAULT_PORT
   end
 
   def self.raw_connect(hostname, port, options)


### PR DESCRIPTION
The 8443 port was the default port for Openshift v3, on v4 Openshift moved to using API Groups which means it has the same port for all API endpoints.