### PR TITLE
Fail verify_credentials for Openshift v3 clusters

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -106,7 +106,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Ku
       # If we're given an OpenShift object lookup its v4 API Group
       api_group = self.class.api_group_for_kind(kind)
       if api_group
-        openshift_client_key  = File.join(path, "/apps/#{api_group}")
+        openshift_client_key = File.join(path, "/apps/#{api_group}")
         @clients[openshift_client_key] ||= connect(:api_group => api_group, :version => api_version)
       end
 

--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -50,7 +50,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Ku
   end
 
   def self.openshift_connect(hostname, port, options)
-    api_group = options[:api_group] || "apps.openshift.io/v1"
+    api_group = options[:api_group] || "config.openshift.io/v1"
     api_path, api_version = api_group.split("/")
 
     options = {:path => "/apis/#{api_path}", :version => api_version}.merge(options)
@@ -62,6 +62,10 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Ku
 
     ocp = openshift_connect(hostname, port, options)
     !!ocp&.api_valid?
+  rescue Kubeclient::ResourceNotFoundError
+    # If the /apis/config.openshift.io/v1 endpoint isn't available then we have
+    # connected to an unsupported version of openshift
+    raise MiqException::Error, _("Unsupported OpenShift version")
   end
 
   def self.api_group_for_kind(kind)

--- a/spec/models/manageiq/providers/openshift/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager_spec.rb
@@ -1,4 +1,17 @@
 describe ManageIQ::Providers::Openshift::ContainerManager do
+  describe ".verify_default_credentials" do
+    context "with a v3 cluster" do
+      it "raises an unsupported exception" do
+        allow(Kubeclient::Client)
+          .to receive(:new)
+          .with(URI.parse("https://openshiftv3:8443/oapi"), "v1", anything)
+          .and_raise(Kubeclient::ResourceNotFoundError.new(404, "404 Not Found", nil))
+
+        expect { described_class.verify_default_credentials("openshiftv3", 8443, {:path => "/oapi"}) }.to raise_error(MiqException::Error, "Unsupported Openshift version")
+      end
+    end
+  end
+
   it "#catalog_types" do
     ems = FactoryBot.create(:ems_openshift)
     expect(ems.catalog_types).to include("generic_container_template")

--- a/spec/models/manageiq/providers/openshift/container_manager_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager_spec.rb
@@ -2,12 +2,14 @@ describe ManageIQ::Providers::Openshift::ContainerManager do
   describe ".verify_default_credentials" do
     context "with a v3 cluster" do
       it "raises an unsupported exception" do
+        require "kubeclient"
+
         allow(Kubeclient::Client)
           .to receive(:new)
           .with(URI.parse("https://openshiftv3:8443/oapi"), "v1", anything)
           .and_raise(Kubeclient::ResourceNotFoundError.new(404, "404 Not Found", nil))
 
-        expect { described_class.verify_default_credentials("openshiftv3", 8443, {:path => "/oapi"}) }.to raise_error(MiqException::Error, "Unsupported Openshift version")
+        expect { described_class.verify_default_credentials("openshiftv3", 8443, {:path => "/oapi"}) }.to raise_error(MiqException::Error, "Unsupported OpenShift version")
       end
     end
   end

--- a/spec/vcr_cassettes/container_template.yml
+++ b/spec/vcr_cassettes/container_template.yml
@@ -182,49 +182,6 @@ http_interactions:
   recorded_at: Tue, 10 Jan 2023 15:02:41 GMT
 - request:
     method: get
-    uri: https://host.example.com:8443/apis/apps.openshift.io/v1
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - "*/*"
-      User-Agent:
-      - rest-client/2.1.0 (linux-gnu x86_64) ruby/3.0.4p208
-      Authorization:
-      - Bearer theToken
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Audit-Id:
-      - 6f26dc0f-8946-4664-b7f4-a2e89eb250d8
-      - 6f26dc0f-8946-4664-b7f4-a2e89eb250d8
-      Cache-Control:
-      - no-cache, private
-      - no-store
-      Content-Length:
-      - '999'
-      Content-Type:
-      - application/json
-      Date:
-      - Tue, 10 Jan 2023 15:02:41 GMT
-      X-Kubernetes-Pf-Flowschema-Uid:
-      - 1b99b53f-667e-43b6-af56-957dcd30e4a7
-      X-Kubernetes-Pf-Prioritylevel-Uid:
-      - 956bc4ac-462e-42d5-a2da-66c720f4480b
-    body:
-      encoding: UTF-8
-      string: '{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"apps.openshift.io/v1","resources":[{"name":"deploymentconfigs","singularName":"","namespaced":true,"kind":"DeploymentConfig","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["dc"],"categories":["all"],"storageVersionHash":"6xyoXGsxfiA="},{"name":"deploymentconfigs/instantiate","singularName":"","namespaced":true,"kind":"DeploymentRequest","verbs":["create"]},{"name":"deploymentconfigs/log","singularName":"","namespaced":true,"kind":"DeploymentLog","verbs":["get"]},{"name":"deploymentconfigs/rollback","singularName":"","namespaced":true,"kind":"DeploymentConfigRollback","verbs":["create"]},{"name":"deploymentconfigs/scale","singularName":"","namespaced":true,"group":"extensions","version":"v1beta1","kind":"Scale","verbs":["get","patch","update"]},{"name":"deploymentconfigs/status","singularName":"","namespaced":true,"kind":"DeploymentConfig","verbs":["get","patch","update"]}]}
-
-        '
-    http_version:
-  recorded_at: Tue, 10 Jan 2023 15:02:41 GMT
-- request:
-    method: get
     uri: https://host.example.com:8443/api/v1
     body:
       encoding: US-ASCII


### PR DESCRIPTION
We were using `/apis/apps.openshift.io/v1` as the API group to check for ocpv4, but ocpv3 actually responds to this API group and v3 clusters were passing.