### PR TITLE
Drop lib/gem-name.rb in favor of lib/gem/name.rb

### DIFF
--- a/lib/manageiq-providers-openshift.rb
+++ b/lib/manageiq-providers-openshift.rb
@@ -1,2 +1,0 @@
-require "manageiq/providers/openshift/engine"
-require "manageiq/providers/openshift/version"

--- a/lib/manageiq/providers/openshift.rb
+++ b/lib/manageiq/providers/openshift.rb
@@ -1,1 +1,3 @@
 require "manageiq/providers/openshift/engine"
+require "manageiq/providers/openshift/version"
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[ManageIQ::Providers::Kubernetes::Engine.root.join("spec/support/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
-require "manageiq-providers-openshift"
+require "manageiq/providers/openshift"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
Adopt convention already supported by bundler and required by zeitwerk so we don't need to tell zeitwerk to ignore this lib/gem-name.rb file