### PR TITLE
Drop require_nested 

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -3,22 +3,6 @@ ManageIQ::Providers::Kubernetes::ContainerManager.include(ActsAsStiLeafClass)
 class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Kubernetes::ContainerManager
   DEFAULT_EXTERNAL_LOGGING_ROUTE_NAME = "logging-kibana-ops".freeze
 
-  require_nested :Container
-  require_nested :ContainerGroup
-  require_nested :ContainerNode
-  require_nested :ContainerImage
-  require_nested :ContainerTemplate
-  require_nested :EventCatcher
-  require_nested :EventParser
-  require_nested :MetricsCollectorWorker
-  require_nested :OrchestrationStack
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :ServiceInstance
-  require_nested :ServiceOffering
-  require_nested :ServiceParametersSet
-  require_nested :Options
-
   include ManageIQ::Providers::Openshift::ContainerManager::Options
 
   # Override HasMonitoringManagerMixin

--- a/app/models/manageiq/providers/openshift/container_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/event_catcher.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Openshift::ContainerManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
 end

--- a/app/models/manageiq/providers/openshift/container_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/metrics_collector_worker.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers
   class Openshift::ContainerManager::MetricsCollectorWorker < BaseManager::MetricsCollectorWorker
-    require_nested :Runner
-
     self.default_queue_name = "openshift"
 
     def friendly_name

--- a/app/models/manageiq/providers/openshift/container_manager/orchestration_stack.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/orchestration_stack.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Openshift::ContainerManager::OrchestrationStack < ManageIQ::Providers::ContainerManager::OrchestrationStack
-  require_nested :Status
 end

--- a/app/models/manageiq/providers/openshift/container_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/refresh_worker.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Openshift::ContainerManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-  require_nested :WatchThread
 end

--- a/app/models/manageiq/providers/openshift/inventory.rb
+++ b/app/models/manageiq/providers/openshift/inventory.rb
@@ -1,5 +1,2 @@
 class ManageIQ::Providers::Openshift::Inventory < ManageIQ::Providers::Kubernetes::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
 end

--- a/app/models/manageiq/providers/openshift/inventory/collector.rb
+++ b/app/models/manageiq/providers/openshift/inventory/collector.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Openshift::Inventory::Collector < ManageIQ::Providers::Kubernetes::Inventory::Collector
-  require_nested :ContainerManager
 end

--- a/app/models/manageiq/providers/openshift/inventory/collector/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/inventory/collector/container_manager.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Openshift::Inventory::Collector::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Collector::ContainerManager
-  require_nested :WatchNotice
-
   def api_version
     @api_version ||= cluster_version.status.desired.version
   end

--- a/app/models/manageiq/providers/openshift/inventory/parser.rb
+++ b/app/models/manageiq/providers/openshift/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Openshift::Inventory::Parser < ManageIQ::Providers::Kubernetes::Inventory::Parser
-  require_nested :ContainerManager
 end

--- a/app/models/manageiq/providers/openshift/inventory/parser/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/inventory/parser/container_manager.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Openshift::Inventory::Parser::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Parser::ContainerManager
-  require_nested :WatchNotice
-
   include ManageIQ::Providers::Openshift::Inventory::Parser::OpenshiftParserMixin
 
   def ems_inv_populate_collections

--- a/app/models/manageiq/providers/openshift/inventory/persister.rb
+++ b/app/models/manageiq/providers/openshift/inventory/persister.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Openshift::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :ContainerManager
-
   def add_collection_directly(collection)
     @collections[collection.name] = collection
   end

--- a/app/models/manageiq/providers/openshift/inventory/persister/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/inventory/persister/container_manager.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Openshift::Inventory::Persister::ContainerManager < ManageIQ::Providers::Kubernetes::Inventory::Persister::ContainerManager
-  require_nested :WatchNotice
-
   def initialize_inventory_collections
     super
 

--- a/app/models/manageiq/providers/openshift/monitoring_manager.rb
+++ b/app/models/manageiq/providers/openshift/monitoring_manager.rb
@@ -1,8 +1,6 @@
 ManageIQ::Providers::Kubernetes::MonitoringManager.include(ActsAsStiLeafClass)
 
 class ManageIQ::Providers::Openshift::MonitoringManager < ManageIQ::Providers::Kubernetes::MonitoringManager
-  require_nested :EventCatcher
-
   belongs_to :parent_manager,
              :foreign_key => :parent_ems_id,
              :class_name  => "ManageIQ::Providers::Openshift::ContainerManager",

--- a/app/models/manageiq/providers/openshift/monitoring_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/openshift/monitoring_manager/event_catcher.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Openshift::MonitoringManager::EventCatcher < ManageIQ::Providers::BaseManager::EventCatcher
-  require_nested :Runner
-
   def self.settings_name
     :event_catcher_prometheus
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854