### PR TITLE
drop use of unsupported_reason_add

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager/container_template.rb
+++ b/app/models/manageiq/providers/openshift/container_manager/container_template.rb
@@ -12,7 +12,7 @@ class ManageIQ::Providers::Openshift::ContainerManager::ContainerTemplate < Mana
   end
 
   supports :instantiate do
-    unsupported_reason_add(:instantiate, instantiate_unsupported_reason) unless instantiate_supported?
+    instantiate_unsupported_reason unless instantiate_supported?
   end
 
   def instantiate(params, project = nil, labels = nil)


### PR DESCRIPTION
@agrare I see that we added `instantiate_supported?` in c7213d39

Do we still need that?
I don't see it defined or extended anywhere.

Alternatively, can we just use `instantiate_unsupported_reason` and drop the `instantiate_supported?` ?

**ANSWER:** punting for now

---

part of:
- https://github.com/ManageIQ/manageiq/pull/22898
 
Deprecating `unsupported_reason_add`. Returning the string instead

Note, these are all the same:

```ruby
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports_feature2?
unsupported_reason_add(:feature, unsupported_reason(:feature2)) unless supports?(:feature2)
unsupported_reason(:feature2) unless supports?(:feature2)
unsupported_reason(:feature2)
```
