### PR TITLE
Add annotations to custom attributes on summary pages for routes and templates

### DIFF
--- a/app/models/manageiq/providers/openshift/inventory/parser/openshift_parser_mixin.rb
+++ b/app/models/manageiq/providers/openshift/inventory/parser/openshift_parser_mixin.rb
@@ -34,7 +34,9 @@ module ManageIQ::Providers::Openshift::Inventory::Parser::OpenshiftParserMixin
 
       container_route = persister.container_routes.build(h)
 
+      annotations = parse_annotations(data)
       custom_attributes(container_route, custom_attrs)
+      custom_attributes(container_route, :annotations => annotations)
       taggings(container_route, tags)
     end
   end
@@ -73,6 +75,8 @@ module ManageIQ::Providers::Openshift::Inventory::Parser::OpenshiftParserMixin
 
       container_template = persister.container_templates.build(h)
 
+      annotations = parse_annotations(data)
+      custom_attributes(container_template, :annotations => annotations)
       template_parameters(container_template, parameters)
       custom_attributes(container_template, custom_attrs)
     end

--- a/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/openshift/container_manager/refresher_spec.rb
@@ -139,7 +139,7 @@ shared_examples "openshift refresher VCR tests" do
           'ContainerReplicator'        => 2,
           'ContainerBuild'             => 2,
           'ContainerBuildPod'          => 2,
-          'CustomAttribute'            => 17,
+          'CustomAttribute'            => 25,
           'ContainerTemplateParameter' => 3,
         }
         expected_counts = deleted.collect { |k, d| [k, object_counts[k] - d] }.to_h
@@ -487,7 +487,7 @@ describe ManageIQ::Providers::Openshift::ContainerManager::Refresher do
         'ContainerReplicator'        => 3,
         'ContainerBuild'             => 3,
         'ContainerBuildPod'          => 3,
-        'CustomAttribute'            => 7704,
+        'CustomAttribute'            => 10_188,
       }
     end
 


### PR DESCRIPTION
Relevant PRs:
Providers-Kubernetes: https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/530
UI-Classic: https://github.com/ManageIQ/manageiq-ui-classic/pull/9214
Core ManageIQ: https://github.com/ManageIQ/manageiq/pull/23074



Cross-Repo Tests:
https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/879 
All passing except for known failing test cases in core ManageIQ
