### PR TITLE
Fix Openshift Infra RefreshWorker not starting

### DIFF
--- a/app/models/manageiq/providers/openshift/infra_manager.rb
+++ b/app/models/manageiq/providers/openshift/infra_manager.rb
@@ -36,10 +36,6 @@ class ManageIQ::Providers::Openshift::InfraManager < ManageIQ::Providers::Kubevi
     "0.1.0".freeze
   end
 
-  def default_authentication_type
-    :openshift
-  end
-
   def self.display_name(number = 1)
     n_('Infrastructure Provider (OpenShift Virtualization)', 'Infrastructure Providers (OpenShift Virtualization)', number)
   end


### PR DESCRIPTION
The kubevirt (and thus the openshift) infra_manager delegates authentications to the parent container_manager.
The authtype for the kubevirt/openshift_infra providers is `"kubevirt"`
```
 #<AuthToken:0x00007f7a820fcc70
  id: 4,
  name: "ManageIQ::Providers::Openshift::ContainerManager crc",
  authtype: "kubevirt",
  userid: nil,
  password: nil,
  resource_id: 5,
  resource_type: "ExtManagementSystem",
  created_on: Mon, 09 Sep 2024 20:33:10.231063000 UTC +00:00,
  updated_on: Wed, 25 Sep 2024 15:57:16.238938000 UTC +00:00,
  last_valid_on: Wed, 25 Sep 2024 15:57:16.236882000 UTC +00:00,
  last_invalid_on: Mon, 09 Sep 2024 20:33:18.554444000 UTC +00:00,
  credentials_changed_on: Wed, 25 Sep 2024 15:57:06.701795000 UTC +00:00,
  status: "Valid",
  status_details: "Ok",
  type: "AuthToken",
  auth_key: "[FILTERED]",
```

Even thought the auth status is "Valid" the openshift_infra provider still shows authentication_status_ok? as invalid because it is looking for `auth_type: "openshift"` and finding nothing.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
