### PR TITLE
Fix full refresh error when running a RefreshWorker

### DIFF
--- a/app/models/manageiq/providers/openshift/infra_manager/refresh_memory.rb
+++ b/app/models/manageiq/providers/openshift/infra_manager/refresh_memory.rb
@@ -1,0 +1,2 @@
+class ManageIQ::Providers::Openshift::InfraManager::RefreshMemory < ManageIQ::Providers::Kubevirt::InfraManager::RefreshMemory
+end


### PR DESCRIPTION
```
An unhandled error has occurred: uninitialized constant ManageIQ::Providers::Openshift::RefreshMemory
    @memory ||= provider_class::RefreshMemory.new
                              ^^^^^^^^^^^^^^^
app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb:75:in `memory'
app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb:194:in `block in start_watches'
```

Depends on:
- [ ] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/252
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
