### PR TITLE
Fix refresh worker partial refresh error

### DIFF
--- a/app/models/manageiq/providers/openshift/infra_manager/refresh_worker/runner.rb
+++ b/app/models/manageiq/providers/openshift/infra_manager/refresh_worker/runner.rb
@@ -6,4 +6,16 @@ class ManageIQ::Providers::Openshift::InfraManager::RefreshWorker::Runner < Mana
   def provider_class
     ManageIQ::Providers::Openshift
   end
+
+  def collector_class
+    ManageIQ::Providers::Openshift::Inventory::Collector::InfraManager
+  end
+
+  def partial_refresh_parser_class
+    ManageIQ::Providers::Openshift::Inventory::Parser::InfraManager::PartialRefresh
+  end
+
+  def persister_class
+    ManageIQ::Providers::Openshift::Inventory::Persister::InfraManager
+  end
 end


### PR DESCRIPTION
```
[----] E, [2024-09-25T12:54:33.983014#1039874:c23a8] ERROR -- evm: MIQ(ManageIQ::Providers::Openshift::InfraManager::RefreshWorker::Runner#partial_refresh) Partial refresh failed.
[----] E, [2024-09-25T12:54:33.985633#1039874:c23a8] ERROR -- evm: [NoMethodError]: undefined method `nodes=' for #<ManageIQ::Providers::Openshift::Inventory::Collector:0x00007faf8d8dd288 @    manager=#<ManageIQ::Providers::Openshift::InfraManager id: 6, name: "crc Virtualization Manager", created_on: "2024-09-09 20:33:10.220755000 +0000", updated_on: "2024-09-25 16:53:23.023870210 +0000", guid: "482ceee5-e5cf-402e-80f6-cc5c78cbd0e6", zone_id: 2, type: "ManageIQ::Providers::Openshift::InfraManager", api_version: nil, uid_ems: nil, host_default_vnc_port_start: nil,         host_default_vnc_port_end: nil, provider_region: nil, last_refresh_error: "undefined method `nodes=' for #<ManageIQ::Provider...", last_refresh_date: "2024-09-25 16:53:23.022809523 +0000",     provider_id: nil, realm: nil, tenant_id: 1, project: nil, parent_ems_id: 5, subscription: nil, last_metrics_error: nil, last_metrics_update_date: nil, last_metrics_success_date: nil,           tenant_mapping_enabled: nil, enabled: true, options: nil, zone_before_pause_id: nil, last_inventory_date: nil, capabilities: {}, last_refresh_success_date: nil>, @target=nil>  Method:[block (2 levels) in <class:LogProxy>]
[----] E, [2024-09-25T12:54:33.985799#1039874:c23a8] ERROR -- evm: /home/grare/adam/src/manageiq/manageiq-providers-kubevirt/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb:148:in `partial_refresh'
/home/grare/adam/src/manageiq/manageiq-providers-kubevirt/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb:33:in `block (2 levels) in do_before_work_loop'
/home/grare/adam/src/manageiq/manageiq-providers-kubevirt/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb:14:in `loop' 
/home/grare/adam/src/manageiq/manageiq-providers-kubevirt/app/models/manageiq/providers/kubevirt/infra_manager/refresh_worker/runner.rb:14:in `block in do_before_work_loop'
```

Depends:
- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/251
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
