### PR TITLE
Lock down recursive-open-struct to 1.2.2

### DIFF
--- a/manageiq-providers-openshift.gemspec
+++ b/manageiq-providers-openshift.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "manageiq-providers-kubernetes", "~> 0.1.0"
 
   spec.add_development_dependency "manageiq-style"
-  spec.add_development_dependency "recursive-open-struct", "~> 1.1"
+  spec.add_development_dependency "recursive-open-struct", "~> 1.2.2"
   spec.add_development_dependency "simplecov", ">= 0.21.2"
 end


### PR DESCRIPTION
Fog-kubevirt fails to marshal_dump a recursive-open-struct because of a breaking change in the return value in version 1.3.0.

Likely introduced by https://github.com/aetherknight/recursive-open-struct/pull/72
Fog-kubevirt issue https://github.com/fog/fog-kubevirt/issues/161

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
