### PR TITLE
Delegate refresh_ems class method to parent container manager

### DIFF
--- a/app/models/manageiq/providers/openshift/infra_manager.rb
+++ b/app/models/manageiq/providers/openshift/infra_manager.rb
@@ -12,6 +12,10 @@ class ManageIQ::Providers::Openshift::InfraManager < ManageIQ::Providers::Kubevi
   supports :catalog
   supports :provisioning
 
+  class << self
+    delegate :refresh_ems, :to => ManageIQ::Providers::Openshift::ContainerManager
+  end
+
   def self.ems_type
     @ems_type ||= "openshift_infra".freeze
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,6 +21,8 @@
       :saver_strategy: batch
     :get_container_images: true
     :store_unused_images: true
+  :openshift_infra:
+    :refresh_interval: 0
 :workers:
   :worker_base:
     :event_catcher:


### PR DESCRIPTION
Reasoning here: https://github.com/ManageIQ/manageiq-providers-azure/pull/564#issuecomment-2445034651

@miq-bot assign @agrare
@miq-bot add_label bug, radjabov/yes?
@miq-bot add_reviewer @agrare