### PR TITLE
Fix OSV DDF form pivot value

### DIFF
--- a/app/models/manageiq/providers/openshift/container_manager.rb
+++ b/app/models/manageiq/providers/openshift/container_manager.rb
@@ -37,7 +37,7 @@ class ManageIQ::Providers::Openshift::ContainerManager < ManageIQ::Providers::Ku
       {
         :label => _('OpenShift Virtualization'),
         :value => 'kubevirt',
-        :pivot => 'endpoints.openshift.hostname',
+        :pivot => 'endpoints.kubevirt.hostname',
       },
     ]
   end


### PR DESCRIPTION
Fix an issue when editing an Openshift ContainerManager where the Virtualization Type shows as Disabled even though there is an InfraManager already created.

Here is what the ContainerManager Endpoint roles look like:
```
>> openshift.endpoints.pluck(:role)
=> ["default", "prometheus", "kubevirt"]
```

So it was looking for an "openshift" role and there wasn't one.

Before:
![image](https://github.com/user-attachments/assets/8f9b5646-8887-4bcc-b239-2d906ed109a2)

After:
![image](https://github.com/user-attachments/assets/6a6c0a0a-5202-4e7b-b11d-4a09d0e7f2fa)


<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
