### PR TITLE
Delete unused InfraManager::Connection subclass

### DIFF
--- a/app/models/manageiq/providers/openshift/infra_manager/connection.rb
+++ b/app/models/manageiq/providers/openshift/infra_manager/connection.rb
@@ -1,4 +1,0 @@
-ManageIQ::Providers::Kubevirt::InfraManager::Connection.include(ActsAsStiLeafClass)
-
-class ManageIQ::Providers::Openshift::InfraManager::Connection < ManageIQ::Providers::Kubevirt::InfraManager::Connection
-end


### PR DESCRIPTION
This wass a subclass of the Kubevirt Connection class which abstracted the API groups away from the caller but presented more complications than it was worth when dealing with kubeclient + kubevirt connections.

Deleted by https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/276

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
